### PR TITLE
Release 1.30

### DIFF
--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/azure.datafactory.tools.psd1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/azure.datafactory.tools.psd1
@@ -12,7 +12,7 @@
     RootModule = 'azure.datafactory.tools.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.4.0'
+    ModuleVersion = '1.6.3'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/!AdfPublishOption.class.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/!AdfPublishOption.class.ps1
@@ -1,3 +1,15 @@
+enum TriggerStopTypes
+{
+    AllEnabled
+    DeployableOnly
+}
+
+enum TriggerStartTypes
+{
+    BasedOnSourceCode
+    KeepPreviousState
+}
+
 class AdfPublishOption {
     [hashtable] $Includes = @{}
     [hashtable] $Excludes = @{}
@@ -11,4 +23,6 @@ class AdfPublishOption {
     [Boolean] $DoNotStopStartExcludedTriggers = $false
     [Boolean] $DoNotDeleteExcludedObjects = $true
     [Boolean] $IncrementalDeployment = $false
+    [TriggerStopTypes] $TriggerStopMethod = [TriggerStopTypes]::AllEnabled
+    [TriggerStartTypes] $TriggerStartMethod = [TriggerStartTypes]::BasedOnSourceCode
 }

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Adf.class.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Adf.class.ps1
@@ -22,7 +22,10 @@ class Adf {
     [AdfGlobalProp] $GlobalFactory = [AdfGlobalProp]::new()
     [AdfPublishOption] $PublishOptions
     $ArmTemplateJson
-    
+    [System.Collections.ArrayList] $ActiveTriggers = @{}
+    [System.Collections.ArrayList] $DisabledTriggerNames = @{}
+    [System.Collections.ArrayList] $DeletedObjectNames = @{}
+
     [System.Collections.ArrayList] AllObjects()
     {
         return $this.LinkedServices + $this.Pipelines + $this.DataSets + $this.DataFlows + $this.Triggers + $this.IntegrationRuntimes + $this.Factories + $this.ManagedVirtualNetwork + $this.ManagedPrivateEndpoints + $this.Credentials
@@ -52,6 +55,16 @@ class Adf {
             }
         }
         return $r
+    }
+
+    [Boolean] IsObjectDeleted([string] $ObjectName)
+    {
+        return $this.DeletedObjectNames -contains $ObjectName
+    }
+
+    [Boolean] IsTriggerDisabled([string] $ObjectName)
+    {
+        return $this.DisabledTriggerNames -contains $ObjectName
     }
 
     [System.Collections.ArrayList] GetUnusedDatasets()

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Get-AdfObjectByPattern.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Get-AdfObjectByPattern.ps1
@@ -48,6 +48,10 @@ function Get-AdfObjectByPattern {
         {
             $r = $adf.ManagedPrivateEndpoints | Where-Object { $_.Name -like $name }
         }
+        'Credential'
+        {
+            $r = $adf.Credentials | Where-Object { $_.Name -like $name }
+        }
         default
         {
             Write-Error "ADFT0015: Type [$type] is not supported."

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/GlobalParam.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/GlobalParam.ps1
@@ -24,13 +24,17 @@ function Get-GlobalParam([string]$ResourceGroupName, [string]$DataFactoryName)
   }
   catch {
     Write-Error -Exception $_.Exception
+    $response = ""  # Workaround when ADF service returns error 404 for newly created ADF
   }
   return $response
 }
 
 
-function Set-GlobalParam([string]$ResourceGroupName, [string]$DataFactoryName, $value)
+function Set-GlobalParam([Adf] $adf)
 {
+  $ResourceGroupName = $adf.ResourceGroupName
+  $DataFactoryName = $adf.Name
+
   $azContext = Get-AzContext
   [string] $SubscriptionID = $azContext.Subscription.Id
   $azProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
@@ -41,8 +45,10 @@ function Set-GlobalParam([string]$ResourceGroupName, [string]$DataFactoryName, $
       'Authorization'='Bearer ' + $token.AccessToken
   }
 
+  $gp = ($adf.GlobalFactory.body | ConvertFrom-Json).properties.globalParameters | ConvertTo-Json -Depth 50
+
   $body = "{
-    ""properties"": { ""adftools_deployment_state"": { ""value"": ""$value AJHIUHWIUI"", ""type"": ""Object"" }  }
+    ""properties"": $gp
   }"
 
   $restUri = "https://management.azure.com/subscriptions/$SubscriptionID/resourcegroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/globalParameters/default?api-version=2018-06-01"

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/ObjectProperty.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/ObjectProperty.ps1
@@ -25,7 +25,9 @@ function Update-ObjectProperty {
         $exp = "`$obj.$path = `$$value"
     } elseif ($fieldType -eq [DateTime]) {
         Write-Debug "Setting as DateTime value"
-        $exp = "`$obj.$path = `"$value`""
+        $datevalue = [DateTime]$value
+        $utcvalue = Get-Date $datevalue -Format "yyyy-MM-ddTHH:mm:ss.fffZ"
+        $exp = "`$obj.$path = `"$utcvalue`""
     } elseif ($fieldType -eq [System.Management.Automation.PSCustomObject]) {
         Write-Debug "Setting as json value"
         $jvalue = ConvertFrom-Json $value

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObject.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObject.ps1
@@ -68,6 +68,15 @@ function Remove-AdfObject {
                     -Force -ErrorVariable err -ErrorAction Stop | Out-Null
             }
             "Trigger" {
+                # Stop trigger if enabled before delete it
+                if ($obj.RuntimeState -eq 'Started') {
+                    Write-Verbose "Disabling trigger: $name..." 
+                    Stop-AzDataFactoryV2Trigger `
+                        -ResourceGroupName $ResourceGroupName `
+                        -DataFactoryName $DataFactoryName `
+                        -Name $name `
+                        -Force -ErrorVariable err -ErrorAction Stop | Out-Null
+                }
                 Remove-AzDataFactoryV2Trigger `
                     -ResourceGroupName $ResourceGroupName `
                     -DataFactoryName $DataFactoryName `
@@ -79,7 +88,7 @@ function Remove-AdfObject {
                     -type_plural 'credentials' `
                     -name $name `
                     -adfInstance $adfInstance `
-                    -Force -ErrorVariable err -ErrorAction Stop | Out-Null
+                    -ErrorVariable err -ErrorAction Stop | Out-Null
             }
             "DoNothing" {
 

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObjectIfNotInSource.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObjectIfNotInSource.ps1
@@ -16,6 +16,7 @@ function Remove-AdfObjectIfNotInSource {
     {
         Write-Verbose "Object [$simtype].[$name] hasn't been found in the source - to be deleted."
         Remove-AdfObject -adfSource $adfSource -obj $adfTargetObj -adfInstance $adfInstance
+        $adf.DeletedObjectNames.Add("$type.$name")
     }
     else {
         Write-Verbose "Object [$simtype].[$name] is in the source - won't be delete."

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Save-AdfObjectAsFile.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Save-AdfObjectAsFile.ps1
@@ -4,7 +4,13 @@ function Save-AdfObjectAsFile {
         [parameter(Mandatory = $true)] [AdfObject] $obj
     )
     
-    $newFileName = Join-Path $obj.Adf.Location "$($obj.Type)\~$($obj.Name).json"
+    $folder = Join-Path -Path $obj.Adf.Location -ChildPath $($obj.Type)
+    if (!(Test-Path $folder)) { 
+        Write-Debug "Creating a folder: $folder"
+        New-Item -Path $folder -ItemType Directory | Out-Null
+    }
+
+    $newFileName = Join-Path -Path $folder -ChildPath "~$($obj.Name).json"
     Write-Debug "Writing file: $newFileName"
 
     $output = ($obj.Body | ConvertTo-Json -Compress:$true -Depth 100)

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Start-Trigger.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Start-Trigger.ps1
@@ -7,6 +7,7 @@ function Start-Trigger {
     )
     Write-Debug "BEGIN: Start-Trigger()"
 
+    Write-Host "- Enabling trigger: $Name"
     $attempts = 5;
     $i = 0
     while ($i -lt $attempts)

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Start-Triggers.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Start-Triggers.ps1
@@ -5,24 +5,60 @@ function Start-Triggers {
     )
     Write-Debug "BEGIN: Start-Triggers()"
 
-    [AdfObject[]] $activeTrigger = $adf.Triggers `
-    | Where-Object { $_.Body.properties.runtimeState -eq "Started" } | ToArray
-    Write-Host ("The number of triggers to start: " + $activeTrigger.Count)
+    Write-Host ("TriggerStartMethod = $($adf.PublishOptions.TriggerStartMethod)")
 
-    #Start active triggers - after cleanup efforts
-    $activeTrigger | ForEach-Object { 
-        Write-Host "- Enabling trigger: $($_.Name)"
-        [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$($_.Name)")
-        $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
-        if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
-            Write-host "- Excluded trigger: $($_.Name)" 
-        } else {
+    # Determine triggers to be started
+    if ($adf.PublishOptions.TriggerStartMethod -eq 'KeepPreviousState') {
+        $activeTriggers = $adf.ActiveTriggers | ToArray
+    } else {
+        $activeTriggers = $adf.Triggers `
+        | Where-Object { $_.Body.properties.runtimeState -eq "Started" } | ToArray
+    }
+
+    [System.Collections.ArrayList] $toBeStarted = @{}
+    if ($null -ne $activeTriggers -and $activeTriggers.Count -gt 0)
+    {
+        $activeTriggers | ForEach-Object { 
+            $isStart = $true
+            $triggerName = $_.Name
+            [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$triggerName")
+            # Check whether a trigger is excluded
+            $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
+            if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
+                Write-Host "- Excluded trigger: $triggerName" 
+                $isStart = $false
+            } 
+            # Check whether a trigger has been deleted
+            if ($isStart -and $adf.IsObjectDeleted("trigger.$triggerName")) {
+                Write-Host "- Deleted trigger: $triggerName" 
+                $isStart = $false
+            }
+            # Check whether a trigger has not been stopped    #-and $adf.PublishOptions.TriggerStartMethod -eq 'BasedOnSourceCode' `
+            if ($isStart -and $adf.PublishOptions.TriggerStopMethod  -eq 'DeployableOnly' `
+                         -and $adf.IsTriggerDisabled("$triggerName") -eq $false) {
+                Write-Host "- Trigger already started: $triggerName" 
+                $isStart = $false
+            }
+            if ($isStart) {
+                $toBeStarted.Add($triggerName) | Out-Null
+            }
+        }
+    }
+
+    Write-Host ("The number of triggers to start: " + $toBeStarted.Count)
+
+    # Start triggers
+    if ($toBeStarted.Count -gt 0)
+    {
+        Write-Host "Starting triggers:"
+        $toBeStarted | ForEach-Object { 
             Start-Trigger `
             -ResourceGroupName $adf.ResourceGroupName `
             -DataFactoryName $adf.Name `
-            -Name $_.Name `
+            -Name $_ `
             | Out-Null
         }
+        Write-Host "Complete starting triggers."
     }
 
     Write-Debug "END: Start-Triggers()"

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Stop-Triggers.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Stop-Triggers.ps1
@@ -10,30 +10,61 @@ function Stop-Triggers {
     if ($null -ne $triggersADF) 
     {
         # Goal: Stop all active triggers (<>Stopped) present in ADF service
-        $triggersToStop = $triggersADF | Where-Object { $_.RuntimeState -ne "Stopped" } | ToArray
+        $activeTriggers = $triggersADF | Where-Object { $_.RuntimeState -ne "Stopped" } | ToArray
+        $adf.activeTriggers = $activeTriggers       # Remember to use after the deployment when TriggerStartMethod = 'KeepPreviousState'
         $allAdfTriggersArray = $triggersADF | ToArray
-        Write-Host ("The number of triggers to stop: " + $triggersToStop.Count + " (out of $($allAdfTriggersArray.Count))")
+        Write-Host ("The number of active triggers: " + $activeTriggers.Count + " (out of $($allAdfTriggersArray.Count))")
+        Write-Host ("TriggerStopMethod = $($adf.PublishOptions.TriggerStopMethod)")
 
-        #Stop all triggers
-        if ($null -ne $triggersToStop -and $triggersToStop.Count -gt 0)
+        # Determine triggers to be stopped
+        [System.Collections.ArrayList] $toBeStopped = @{}
+        if ($null -ne $activeTriggers -and $activeTriggers.Count -gt 0)
         {
-            Write-Host "Stopping deployed triggers:"
-            $triggersToStop | ForEach-Object { 
-                [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$($_.Name)")
-                $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
-                if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
-                    Write-host "- Excluded trigger: $($_.Name)" 
-                } else {
-                    Stop-Trigger `
-                    -ResourceGroupName $adf.ResourceGroupName `
-                    -DataFactoryName $adf.Name `
-                    -Name $_.Name `
-                    | Out-Null
+            $activeTriggers | ForEach-Object { 
+                $deploy = $true
+                $triggerName = $_.Name
+                [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$triggerName")
+                # Check whether a trigger is not for deployment
+                if ($adf.PublishOptions.TriggerStopMethod -eq 'DeployableOnly') {
+                    $sourceObject = Get-AdfObjectByName -adf $adf -name $triggerName -type 'Trigger'
+                    if ($null -eq $sourceObject -or $sourceObject.ToBeDeployed -eq $false) {
+                        Write-Host "- Ignored trigger: $triggerName"
+                        $deploy = $false
+                    }
+                }
+                # Check whether a trigger is excluded
+                if ($deploy) {
+                    $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
+                    if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
+                        Write-Host "- Excluded trigger: $triggerName"
+                        $deploy = $false
+                    } 
+                }
+                if ($deploy) {
+                    $toBeStopped.Add($triggerName) | Out-Null
                 }
             }
-            Write-Host "Complete stopping deployed triggers"
         }
+        Write-Host ("The number of triggers to stop: " + $toBeStopped.Count)
 
+        # Stop triggers
+        if ($toBeStopped.Count -gt 0)
+        {
+            Write-Host "Stopping deployed triggers:"
+            $toBeStopped | ForEach-Object { 
+                Stop-Trigger `
+                -ResourceGroupName $adf.ResourceGroupName `
+                -DataFactoryName $adf.Name `
+                -Name $_ `
+                | Out-Null
+            }
+            Write-Host "Complete stopping deployed triggers."
+        }
+        $adf.DisabledTriggerNames = $toBeStopped
+    }
+    else 
+    {
+        Write-Host ("No remote triggers found.")
     }
 
     Write-Debug "END: Stop-Triggers()"

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Test-LinkedServiceConnection.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Test-LinkedServiceConnection.ps1
@@ -2,7 +2,11 @@
 # https://datathirst.net/blog/2018/9/23/adfv2-testing-linked-services
 
 
-function Get-Bearer([string]$TenantID, [string]$ClientID, [string]$ClientSecret)
+function Get-Bearer(
+  [string] $TenantID, 
+  [string] $ClientID, 
+  [string] $ClientSecret
+)
 {
   $TokenEndpoint = {https://login.windows.net/{0}/oauth2/token} -f $TenantID 
   $ARMResource = "https://management.core.windows.net/";
@@ -14,7 +18,7 @@ function Get-Bearer([string]$TenantID, [string]$ClientID, [string]$ClientSecret)
           'client_secret' = $ClientSecret
   }
 
-  $params = @{
+  $request = @{
       ContentType = 'application/x-www-form-urlencoded'
       Headers = @{'accept'='application/json'}
       Body = $Body
@@ -22,48 +26,138 @@ function Get-Bearer([string]$TenantID, [string]$ClientID, [string]$ClientSecret)
       URI = $TokenEndpoint
   }
 
-  $token = Invoke-RestMethod @params
+  $token = Invoke-RestMethod @request
 
   return "Bearer " + ($token.access_token).ToString()
 }
 
 
-function Get-LinkedServiceBody([string]$LinkedServiceName, [string]$DataFactoryName, [string]$ResourceGroupName, [string]$BearerToken)
+function Get-LinkedServiceBody(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $BearerToken, 
+  [string] $SubscriptionID
+)
 {
+  Write-Debug "BEGIN: Get-LinkedServiceBody()"
   $ADFEndpoint = "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/linkedservices/$($LinkedServiceName)?api-version=2018-06-01"
 
-  $params = @{
+  $request = @{
       ContentType = 'application/json'
       Headers = @{'accept'='application/json';'Authorization'=$BearerToken}
       Method = 'GET'
       URI = $ADFEndpoint
   }
 
-  $a = Invoke-RestMethod @params
+  $a = Invoke-RestMethod @request
+  Write-Debug "END: Get-LinkedServiceBody()"
+  return ConvertTo-Json -InputObject @{"linkedService" = $a} -Depth 50
+}
+
+function Get-LinkedServiceBodyAzRestMethod(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $SubscriptionID,
+  $Params
+)
+{
+  Write-Debug "BEGIN: Get-LinkedServiceBodyAzRestMethod()"
+
+  $ADFEndpoint = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/linkedservices/$($LinkedServiceName)?api-version=2018-06-01"
+
+  $request = @{
+      Path = $ADFEndpoint
+      Method = 'GET'
+  }
+
+  $a = Invoke-AzRestMethod @request
+  $a = ($a.Content | ConvertFrom-Json)
+  #Write-Debug (ConvertTo-Json -InputObject @{"linkedService" = $a} -Depth 50)
+  Write-Debug "END: Get-LinkedServiceBodyAzRestMethod()"
   return ConvertTo-Json -InputObject @{"linkedService" = $a} -Depth 50
 }
 
 
-function Test-LinkedServiceConnection([string]$LinkedServiceName, [string]$DataFactoryName, [string]$ResourceGroupName, [string]$BearerToken)
+function Test-LinkedServiceConnection(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $BearerToken, 
+  [string] $SubscriptionID,
+  $Params
+)
 {
+  Write-Debug "BEGIN: Test-LinkedServiceConnection()"
 
-  $body = Get-LinkedServiceBody -LinkedServiceName $LinkedServiceName -DataFactoryName $DataFactoryName -ResourceGroupName $ResourceGroupName -BearerToken $bearerToken
+  $body = Get-LinkedServiceBody -LinkedServiceName $LinkedServiceName -DataFactoryName $DataFactoryName -ResourceGroupName $ResourceGroupName -BearerToken $bearerToken -SubscriptionID $SubscriptionID
 
   $AzureEndpoint = "https://management.azure.com/subscriptions/$SubscriptionID/resourcegroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/testConnectivity?api-version=2018-06-01"
 
-  $params = @{
+  if ($Params) {
+    Write-Verbose "Found input parameters for this Linked Service, adding to the API request..."
+    $j = ConvertFrom-Json $body 
+    $j.linkedService.properties.parameters = $Params
+    $body = ConvertTo-Json -InputObject $j -Depth 50
+  }
+
+  Write-Verbose '============== Linked Service to being connection tested ============='
+  Write-Verbose $body
+  Write-Verbose '======================================================================'
+  
+  $request = @{
       ContentType = 'application/json'
       Headers = @{'accept'='application/json';'Authorization'=$BearerToken}
       Body = $Body
-      Method = 'Post'
+      Method = 'POST'
       Uri = $AzureEndpoint
   }
 
   try {
-    $response = Invoke-RestMethod @params
+    $response = Invoke-RestMethod @request
   }
   catch {
     Write-Error -Exception $_.Exception
   }
+  Write-Debug "END: Test-LinkedServiceConnection()"
   return $response
+}
+
+function Test-LinkedServiceConnectionAzRestMethod(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $SubscriptionID,
+  $Params
+)
+{
+  Write-Debug "BEGIN: Test-LinkedServiceConnectionAzRestMethod()"
+
+  $body = Get-LinkedServiceBodyAzRestMethod -LinkedServiceName $LinkedServiceName -DataFactoryName $DataFactoryName -ResourceGroupName $ResourceGroupName -SubscriptionID $SubscriptionID
+
+  $AzureEndpoint = "/subscriptions/$SubscriptionID/resourcegroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/testConnectivity?api-version=2018-06-01"
+
+  if ($Params) {
+    Write-Verbose "Found input parameters for this Linked Service, adding to the API request..."
+    $j = ConvertFrom-Json $body 
+    $j.linkedService.properties.parameters = $Params
+    $body = ConvertTo-Json -InputObject $j -Depth 50
+  }
+
+  $request = @{
+      Path = $AzureEndpoint
+      Payload = $Body
+      Method = 'POST'
+  }
+
+  try {
+    $response = Invoke-AzRestMethod @request
+  }
+  catch {
+    # Note: Invoke-AzRestMethod fails when payload indicates failure and error will be printed. Not fully feature parity with LinkedServiceConnection
+    Write-Error -Exception $_.Exception
+  }
+  Write-Debug "END: Test-LinkedServiceConnectionAzRestMethod()"
+  return ($response.Content | ConvertFrom-Json)
 }

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Update-GlobalParameters.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/private/Update-GlobalParameters.ps1
@@ -27,12 +27,10 @@ param
             }
             $targetAdf.GlobalParameters = $newGlobalParameters
 
-            # Write-Host "--- newGlobalParameters ---"
-            #$newGlobalParameters.Values | Out-Host
-
             if ($newGlobalParameters.Count -gt 0) {
                 Write-Verbose "Updating $($newGlobalParameters.Count) global parameters..."
-                Set-AzDataFactoryV2 -InputObject $targetAdf -Force | Out-Null
+                #Set-AzDataFactoryV2 -InputObject $targetAdf -Force | Out-Null
+                Set-GlobalParam($adf)
                 Write-Host "Update of $($newGlobalParameters.Count) global parameters complete."
             }
         }

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/public/Import-AdfFromFolder.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/public/Import-AdfFromFolder.ps1
@@ -37,7 +37,9 @@ function Import-AdfFromFolder {
 
     if ( !(Test-Path -Path $RootFolder) ) { Write-Error "ADFT0019: Folder '$RootFolder' doesn't exist." }
     
-    $adf.Location = $RootFolder
+    $adf.Location = Resolve-Path $RootFolder
+    $adf.PublishOptions = New-AdfPublishOption
+    Write-Verbose "Resolved RootFolder = $($adf.Location)"
 
     Import-AdfObjects -Adf $adf -All $adf.IntegrationRuntimes -RootFolder $RootFolder -SubFolder "integrationRuntime" | Out-Null
     Write-Host ("IntegrationRuntimes: {0} object(s) loaded." -f $adf.IntegrationRuntimes.Count)

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/public/New-AdfPublishOption.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/public/New-AdfPublishOption.ps1
@@ -45,6 +45,7 @@ function New-AdfPublishOption {
             Write-Error "ADFT0026: File does not exist: $FilterFilePath"
         }
         $FilterText = Get-Content -Path $FilterFilePath -Encoding "UTF8"
+        if ($null -eq $FilterText) { $FilterText = '' }
 
         $FilterArray = $FilterText.Replace(',', "`n").Replace("`r`n", "`n").Split("`n");
 

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2FromJson.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2FromJson.ps1
@@ -168,7 +168,7 @@ function Publish-AdfV2FromJson {
         }
 
         if ($null -eq $targetAdf) {
-            Write-Host "The process is exiting the function. Do fix the issue and run again."
+            Write-Host "ADFT0032: The process is exiting the function. Do fix the issue and run again."
             return 
         }
     }
@@ -304,12 +304,13 @@ function Publish-AdfV2FromJson {
         $adfIns.AllObjects() | ForEach-Object {
             Remove-AdfObjectIfNotInSource -adfSource $adf -adfTargetObj $_ -adfInstance $adfIns
         }
+        Write-Host "Deleted $($adf.DeletedObjectNames.Count) objects from ADF service."
     } else {
         Write-Host "Operation skipped as publish option 'DeleteNotInSource' = false"
     }
 
     Write-Host "===================================================================================";
-    Write-Host "STEP: Starting all triggers..."
+    Write-Host "STEP: Starting triggers..."
     if ($opt.StopStartTriggers -eq $true) {
         Start-Triggers -adf $adf
     } else {

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2UsingArm.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2UsingArm.ps1
@@ -124,7 +124,7 @@ function Publish-AdfV2UsingArm {
         }
 
         if ($null -eq $targetAdf) {
-            Write-Host "The process is exiting the function. Do fix the issue and run again."
+            Write-Host "ADFT0032: The process is exiting the function. Do fix the issue and run again."
             return 
         }
     }

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/public/Test-AdfCode.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/public/Test-AdfCode.ps1
@@ -86,8 +86,8 @@ function Test-AdfCode {
         }
     }
 
-    Write-Host "Checking names of datasets, pipelines, dataflows..."
-    $adf.LinkedServices + $adf.DataSets + $adf.Pipelines + $adf.DataFlows | ForEach-Object {
+    Write-Host "Checking names of linkedservices, datasets, dataflows..."
+    $adf.LinkedServices + $adf.DataSets + $adf.DataFlows | ForEach-Object {
         [string] $name = $_.Name
         if ($name.Contains('-')) {
             Write-Warning "Dashes ('-') are not allowed in the names of linked services, data flows, and datasets ($name)."

--- a/buildDataFactoryTask/ps_modules/azure.datafactory.tools/public/Test-AdfLinkedService.ps1
+++ b/buildDataFactoryTask/ps_modules/azure.datafactory.tools/public/Test-AdfLinkedService.ps1
@@ -1,36 +1,89 @@
 function Test-AdfLinkedService {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'AzRestMethod')]
     param (
-        [parameter(Mandatory = $true)] 
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $LinkedServiceName,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $DataFactoryName,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $ResourceGroupName,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $SubscriptionID,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $TenantID,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $ClientID,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $ClientSecret
     )
+    Write-Debug "BEGIN: Test-AdfLinkedService(ParameterSetName = $($PSCmdlet.ParameterSetName))"
 
-    $bearerToken = Get-Bearer -TenantID $TenantID -ClientID $ClientID -ClientSecret $ClientSecret
+    if ($PSCmdlet.ParameterSetName -eq "ClientDetails") {
+        $bearerToken = Get-Bearer -TenantID $TenantID -ClientID $ClientID -ClientSecret $ClientSecret
+    }
+    $defFile = $false
+    if ($LinkedServiceName.EndsWith('.json'))
+    {
+        Write-Host "Definition of Linked Services in json file: $LinkedServiceName"
+        $definitionFile = Get-Content -Path $LinkedServiceName -Encoding utf8 -Raw
+        $j = $definitionFile | ConvertFrom-Json
+        $list = $j.linkedServices
+        Write-Host "Found $($list.Count) name(s) in definition file."
+        $defFile = $true
+    }
+    else {
+        $list = $LinkedServiceName.Split(',')
+        Write-Host "Found $($list.Count) name(s) in comma-separated list."
+    }
 
+    $report = @{}
     $all = 0
     $ok = 0
-    $LinkedServiceName.Split(',') | ForEach-Object { 
+    $list | ForEach-Object { 
         $all += 1
-        $ls = $_
-        Write-Host "Testing ADF Linked Service connection: [$_] ..." 
-        $r = Test-LinkedServiceConnection -LinkedServiceName $ls -DataFactoryName $DataFactoryName -ResourceGroup $ResourceGroupName -BearerToken $bearerToken
+        if ($defFile) { 
+            $ls = $_.name 
+            $params = $_.parameters
+        } 
+        else 
+        { 
+            $ls = $_ 
+            $params = $null
+        }
+        Write-Host "Testing ADF Linked Service connection: [$ls] ..." 
+        if ($PSCmdlet.ParameterSetName -eq "ClientDetails") {
+            $r = Test-LinkedServiceConnection -LinkedServiceName $ls `
+                -DataFactoryName $DataFactoryName `
+                -ResourceGroup $ResourceGroupName `
+                -BearerToken $bearerToken `
+                -SubscriptionID $SubscriptionID `
+                -Params $params
+        } else {
+            $r = Test-LinkedServiceConnectionAzRestMethod -LinkedServiceName $ls `
+                -DataFactoryName $DataFactoryName `
+                -ResourceGroup $ResourceGroupName `
+                -SubscriptionID $SubscriptionID `
+                -Params $params
+        }
+        $id = [String]::Format("{0:000}) {1}", $all, $ls)
         if ($null -ne $r -and $r.succeeded) {
-            Write-Host "[$_] : Connection successful."
+            Write-Host "$all) [$ls] : Connection successful."
+            $report.Add($id, $true)
             $ok += 1
         } else {
-            Write-Host "[$_] : Connection failed."
+            Write-Host "$all) [$ls] : Connection failed."
+            $report.Add($id, $false)
+            Write-Verbose ($r | ConvertTo-Json)
         }
     }
     
@@ -39,5 +92,8 @@ function Test-AdfLinkedService {
     Write-Host "Failed: $($all-$ok)"
     Write-Host "Total : $all"
 
+    Write-Debug "END: Test-AdfLinkedService()"
+    $result = [ordered]@{Passed = $ok; Failed = ($all-$ok); Total = $all; Report = $report}
+    return $result
 }
 

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/azure.datafactory.tools.psd1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/azure.datafactory.tools.psd1
@@ -12,7 +12,7 @@
     RootModule = 'azure.datafactory.tools.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.4.0'
+    ModuleVersion = '1.6.3'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/!AdfPublishOption.class.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/!AdfPublishOption.class.ps1
@@ -1,3 +1,15 @@
+enum TriggerStopTypes
+{
+    AllEnabled
+    DeployableOnly
+}
+
+enum TriggerStartTypes
+{
+    BasedOnSourceCode
+    KeepPreviousState
+}
+
 class AdfPublishOption {
     [hashtable] $Includes = @{}
     [hashtable] $Excludes = @{}
@@ -11,4 +23,6 @@ class AdfPublishOption {
     [Boolean] $DoNotStopStartExcludedTriggers = $false
     [Boolean] $DoNotDeleteExcludedObjects = $true
     [Boolean] $IncrementalDeployment = $false
+    [TriggerStopTypes] $TriggerStopMethod = [TriggerStopTypes]::AllEnabled
+    [TriggerStartTypes] $TriggerStartMethod = [TriggerStartTypes]::BasedOnSourceCode
 }

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Adf.class.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Adf.class.ps1
@@ -22,7 +22,10 @@ class Adf {
     [AdfGlobalProp] $GlobalFactory = [AdfGlobalProp]::new()
     [AdfPublishOption] $PublishOptions
     $ArmTemplateJson
-    
+    [System.Collections.ArrayList] $ActiveTriggers = @{}
+    [System.Collections.ArrayList] $DisabledTriggerNames = @{}
+    [System.Collections.ArrayList] $DeletedObjectNames = @{}
+
     [System.Collections.ArrayList] AllObjects()
     {
         return $this.LinkedServices + $this.Pipelines + $this.DataSets + $this.DataFlows + $this.Triggers + $this.IntegrationRuntimes + $this.Factories + $this.ManagedVirtualNetwork + $this.ManagedPrivateEndpoints + $this.Credentials
@@ -52,6 +55,16 @@ class Adf {
             }
         }
         return $r
+    }
+
+    [Boolean] IsObjectDeleted([string] $ObjectName)
+    {
+        return $this.DeletedObjectNames -contains $ObjectName
+    }
+
+    [Boolean] IsTriggerDisabled([string] $ObjectName)
+    {
+        return $this.DisabledTriggerNames -contains $ObjectName
     }
 
     [System.Collections.ArrayList] GetUnusedDatasets()

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Get-AdfObjectByPattern.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Get-AdfObjectByPattern.ps1
@@ -48,6 +48,10 @@ function Get-AdfObjectByPattern {
         {
             $r = $adf.ManagedPrivateEndpoints | Where-Object { $_.Name -like $name }
         }
+        'Credential'
+        {
+            $r = $adf.Credentials | Where-Object { $_.Name -like $name }
+        }
         default
         {
             Write-Error "ADFT0015: Type [$type] is not supported."

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/GlobalParam.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/GlobalParam.ps1
@@ -24,13 +24,17 @@ function Get-GlobalParam([string]$ResourceGroupName, [string]$DataFactoryName)
   }
   catch {
     Write-Error -Exception $_.Exception
+    $response = ""  # Workaround when ADF service returns error 404 for newly created ADF
   }
   return $response
 }
 
 
-function Set-GlobalParam([string]$ResourceGroupName, [string]$DataFactoryName, $value)
+function Set-GlobalParam([Adf] $adf)
 {
+  $ResourceGroupName = $adf.ResourceGroupName
+  $DataFactoryName = $adf.Name
+
   $azContext = Get-AzContext
   [string] $SubscriptionID = $azContext.Subscription.Id
   $azProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
@@ -41,8 +45,10 @@ function Set-GlobalParam([string]$ResourceGroupName, [string]$DataFactoryName, $
       'Authorization'='Bearer ' + $token.AccessToken
   }
 
+  $gp = ($adf.GlobalFactory.body | ConvertFrom-Json).properties.globalParameters | ConvertTo-Json -Depth 50
+
   $body = "{
-    ""properties"": { ""adftools_deployment_state"": { ""value"": ""$value AJHIUHWIUI"", ""type"": ""Object"" }  }
+    ""properties"": $gp
   }"
 
   $restUri = "https://management.azure.com/subscriptions/$SubscriptionID/resourcegroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/globalParameters/default?api-version=2018-06-01"

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/ObjectProperty.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/ObjectProperty.ps1
@@ -25,7 +25,9 @@ function Update-ObjectProperty {
         $exp = "`$obj.$path = `$$value"
     } elseif ($fieldType -eq [DateTime]) {
         Write-Debug "Setting as DateTime value"
-        $exp = "`$obj.$path = `"$value`""
+        $datevalue = [DateTime]$value
+        $utcvalue = Get-Date $datevalue -Format "yyyy-MM-ddTHH:mm:ss.fffZ"
+        $exp = "`$obj.$path = `"$utcvalue`""
     } elseif ($fieldType -eq [System.Management.Automation.PSCustomObject]) {
         Write-Debug "Setting as json value"
         $jvalue = ConvertFrom-Json $value

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObject.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObject.ps1
@@ -68,6 +68,15 @@ function Remove-AdfObject {
                     -Force -ErrorVariable err -ErrorAction Stop | Out-Null
             }
             "Trigger" {
+                # Stop trigger if enabled before delete it
+                if ($obj.RuntimeState -eq 'Started') {
+                    Write-Verbose "Disabling trigger: $name..." 
+                    Stop-AzDataFactoryV2Trigger `
+                        -ResourceGroupName $ResourceGroupName `
+                        -DataFactoryName $DataFactoryName `
+                        -Name $name `
+                        -Force -ErrorVariable err -ErrorAction Stop | Out-Null
+                }
                 Remove-AzDataFactoryV2Trigger `
                     -ResourceGroupName $ResourceGroupName `
                     -DataFactoryName $DataFactoryName `
@@ -79,7 +88,7 @@ function Remove-AdfObject {
                     -type_plural 'credentials' `
                     -name $name `
                     -adfInstance $adfInstance `
-                    -Force -ErrorVariable err -ErrorAction Stop | Out-Null
+                    -ErrorVariable err -ErrorAction Stop | Out-Null
             }
             "DoNothing" {
 

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObjectIfNotInSource.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObjectIfNotInSource.ps1
@@ -16,6 +16,7 @@ function Remove-AdfObjectIfNotInSource {
     {
         Write-Verbose "Object [$simtype].[$name] hasn't been found in the source - to be deleted."
         Remove-AdfObject -adfSource $adfSource -obj $adfTargetObj -adfInstance $adfInstance
+        $adf.DeletedObjectNames.Add("$type.$name")
     }
     else {
         Write-Verbose "Object [$simtype].[$name] is in the source - won't be delete."

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Save-AdfObjectAsFile.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Save-AdfObjectAsFile.ps1
@@ -4,7 +4,13 @@ function Save-AdfObjectAsFile {
         [parameter(Mandatory = $true)] [AdfObject] $obj
     )
     
-    $newFileName = Join-Path $obj.Adf.Location "$($obj.Type)\~$($obj.Name).json"
+    $folder = Join-Path -Path $obj.Adf.Location -ChildPath $($obj.Type)
+    if (!(Test-Path $folder)) { 
+        Write-Debug "Creating a folder: $folder"
+        New-Item -Path $folder -ItemType Directory | Out-Null
+    }
+
+    $newFileName = Join-Path -Path $folder -ChildPath "~$($obj.Name).json"
     Write-Debug "Writing file: $newFileName"
 
     $output = ($obj.Body | ConvertTo-Json -Compress:$true -Depth 100)

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Start-Trigger.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Start-Trigger.ps1
@@ -7,6 +7,7 @@ function Start-Trigger {
     )
     Write-Debug "BEGIN: Start-Trigger()"
 
+    Write-Host "- Enabling trigger: $Name"
     $attempts = 5;
     $i = 0
     while ($i -lt $attempts)

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Start-Triggers.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Start-Triggers.ps1
@@ -5,24 +5,60 @@ function Start-Triggers {
     )
     Write-Debug "BEGIN: Start-Triggers()"
 
-    [AdfObject[]] $activeTrigger = $adf.Triggers `
-    | Where-Object { $_.Body.properties.runtimeState -eq "Started" } | ToArray
-    Write-Host ("The number of triggers to start: " + $activeTrigger.Count)
+    Write-Host ("TriggerStartMethod = $($adf.PublishOptions.TriggerStartMethod)")
 
-    #Start active triggers - after cleanup efforts
-    $activeTrigger | ForEach-Object { 
-        Write-Host "- Enabling trigger: $($_.Name)"
-        [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$($_.Name)")
-        $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
-        if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
-            Write-host "- Excluded trigger: $($_.Name)" 
-        } else {
+    # Determine triggers to be started
+    if ($adf.PublishOptions.TriggerStartMethod -eq 'KeepPreviousState') {
+        $activeTriggers = $adf.ActiveTriggers | ToArray
+    } else {
+        $activeTriggers = $adf.Triggers `
+        | Where-Object { $_.Body.properties.runtimeState -eq "Started" } | ToArray
+    }
+
+    [System.Collections.ArrayList] $toBeStarted = @{}
+    if ($null -ne $activeTriggers -and $activeTriggers.Count -gt 0)
+    {
+        $activeTriggers | ForEach-Object { 
+            $isStart = $true
+            $triggerName = $_.Name
+            [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$triggerName")
+            # Check whether a trigger is excluded
+            $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
+            if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
+                Write-Host "- Excluded trigger: $triggerName" 
+                $isStart = $false
+            } 
+            # Check whether a trigger has been deleted
+            if ($isStart -and $adf.IsObjectDeleted("trigger.$triggerName")) {
+                Write-Host "- Deleted trigger: $triggerName" 
+                $isStart = $false
+            }
+            # Check whether a trigger has not been stopped    #-and $adf.PublishOptions.TriggerStartMethod -eq 'BasedOnSourceCode' `
+            if ($isStart -and $adf.PublishOptions.TriggerStopMethod  -eq 'DeployableOnly' `
+                         -and $adf.IsTriggerDisabled("$triggerName") -eq $false) {
+                Write-Host "- Trigger already started: $triggerName" 
+                $isStart = $false
+            }
+            if ($isStart) {
+                $toBeStarted.Add($triggerName) | Out-Null
+            }
+        }
+    }
+
+    Write-Host ("The number of triggers to start: " + $toBeStarted.Count)
+
+    # Start triggers
+    if ($toBeStarted.Count -gt 0)
+    {
+        Write-Host "Starting triggers:"
+        $toBeStarted | ForEach-Object { 
             Start-Trigger `
             -ResourceGroupName $adf.ResourceGroupName `
             -DataFactoryName $adf.Name `
-            -Name $_.Name `
+            -Name $_ `
             | Out-Null
         }
+        Write-Host "Complete starting triggers."
     }
 
     Write-Debug "END: Start-Triggers()"

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Stop-Triggers.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Stop-Triggers.ps1
@@ -10,30 +10,61 @@ function Stop-Triggers {
     if ($null -ne $triggersADF) 
     {
         # Goal: Stop all active triggers (<>Stopped) present in ADF service
-        $triggersToStop = $triggersADF | Where-Object { $_.RuntimeState -ne "Stopped" } | ToArray
+        $activeTriggers = $triggersADF | Where-Object { $_.RuntimeState -ne "Stopped" } | ToArray
+        $adf.activeTriggers = $activeTriggers       # Remember to use after the deployment when TriggerStartMethod = 'KeepPreviousState'
         $allAdfTriggersArray = $triggersADF | ToArray
-        Write-Host ("The number of triggers to stop: " + $triggersToStop.Count + " (out of $($allAdfTriggersArray.Count))")
+        Write-Host ("The number of active triggers: " + $activeTriggers.Count + " (out of $($allAdfTriggersArray.Count))")
+        Write-Host ("TriggerStopMethod = $($adf.PublishOptions.TriggerStopMethod)")
 
-        #Stop all triggers
-        if ($null -ne $triggersToStop -and $triggersToStop.Count -gt 0)
+        # Determine triggers to be stopped
+        [System.Collections.ArrayList] $toBeStopped = @{}
+        if ($null -ne $activeTriggers -and $activeTriggers.Count -gt 0)
         {
-            Write-Host "Stopping deployed triggers:"
-            $triggersToStop | ForEach-Object { 
-                [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$($_.Name)")
-                $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
-                if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
-                    Write-host "- Excluded trigger: $($_.Name)" 
-                } else {
-                    Stop-Trigger `
-                    -ResourceGroupName $adf.ResourceGroupName `
-                    -DataFactoryName $adf.Name `
-                    -Name $_.Name `
-                    | Out-Null
+            $activeTriggers | ForEach-Object { 
+                $deploy = $true
+                $triggerName = $_.Name
+                [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$triggerName")
+                # Check whether a trigger is not for deployment
+                if ($adf.PublishOptions.TriggerStopMethod -eq 'DeployableOnly') {
+                    $sourceObject = Get-AdfObjectByName -adf $adf -name $triggerName -type 'Trigger'
+                    if ($null -eq $sourceObject -or $sourceObject.ToBeDeployed -eq $false) {
+                        Write-Host "- Ignored trigger: $triggerName"
+                        $deploy = $false
+                    }
+                }
+                # Check whether a trigger is excluded
+                if ($deploy) {
+                    $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
+                    if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
+                        Write-Host "- Excluded trigger: $triggerName"
+                        $deploy = $false
+                    } 
+                }
+                if ($deploy) {
+                    $toBeStopped.Add($triggerName) | Out-Null
                 }
             }
-            Write-Host "Complete stopping deployed triggers"
         }
+        Write-Host ("The number of triggers to stop: " + $toBeStopped.Count)
 
+        # Stop triggers
+        if ($toBeStopped.Count -gt 0)
+        {
+            Write-Host "Stopping deployed triggers:"
+            $toBeStopped | ForEach-Object { 
+                Stop-Trigger `
+                -ResourceGroupName $adf.ResourceGroupName `
+                -DataFactoryName $adf.Name `
+                -Name $_ `
+                | Out-Null
+            }
+            Write-Host "Complete stopping deployed triggers."
+        }
+        $adf.DisabledTriggerNames = $toBeStopped
+    }
+    else 
+    {
+        Write-Host ("No remote triggers found.")
     }
 
     Write-Debug "END: Stop-Triggers()"

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Test-LinkedServiceConnection.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Test-LinkedServiceConnection.ps1
@@ -2,7 +2,11 @@
 # https://datathirst.net/blog/2018/9/23/adfv2-testing-linked-services
 
 
-function Get-Bearer([string]$TenantID, [string]$ClientID, [string]$ClientSecret)
+function Get-Bearer(
+  [string] $TenantID, 
+  [string] $ClientID, 
+  [string] $ClientSecret
+)
 {
   $TokenEndpoint = {https://login.windows.net/{0}/oauth2/token} -f $TenantID 
   $ARMResource = "https://management.core.windows.net/";
@@ -14,7 +18,7 @@ function Get-Bearer([string]$TenantID, [string]$ClientID, [string]$ClientSecret)
           'client_secret' = $ClientSecret
   }
 
-  $params = @{
+  $request = @{
       ContentType = 'application/x-www-form-urlencoded'
       Headers = @{'accept'='application/json'}
       Body = $Body
@@ -22,48 +26,138 @@ function Get-Bearer([string]$TenantID, [string]$ClientID, [string]$ClientSecret)
       URI = $TokenEndpoint
   }
 
-  $token = Invoke-RestMethod @params
+  $token = Invoke-RestMethod @request
 
   return "Bearer " + ($token.access_token).ToString()
 }
 
 
-function Get-LinkedServiceBody([string]$LinkedServiceName, [string]$DataFactoryName, [string]$ResourceGroupName, [string]$BearerToken)
+function Get-LinkedServiceBody(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $BearerToken, 
+  [string] $SubscriptionID
+)
 {
+  Write-Debug "BEGIN: Get-LinkedServiceBody()"
   $ADFEndpoint = "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/linkedservices/$($LinkedServiceName)?api-version=2018-06-01"
 
-  $params = @{
+  $request = @{
       ContentType = 'application/json'
       Headers = @{'accept'='application/json';'Authorization'=$BearerToken}
       Method = 'GET'
       URI = $ADFEndpoint
   }
 
-  $a = Invoke-RestMethod @params
+  $a = Invoke-RestMethod @request
+  Write-Debug "END: Get-LinkedServiceBody()"
+  return ConvertTo-Json -InputObject @{"linkedService" = $a} -Depth 50
+}
+
+function Get-LinkedServiceBodyAzRestMethod(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $SubscriptionID,
+  $Params
+)
+{
+  Write-Debug "BEGIN: Get-LinkedServiceBodyAzRestMethod()"
+
+  $ADFEndpoint = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/linkedservices/$($LinkedServiceName)?api-version=2018-06-01"
+
+  $request = @{
+      Path = $ADFEndpoint
+      Method = 'GET'
+  }
+
+  $a = Invoke-AzRestMethod @request
+  $a = ($a.Content | ConvertFrom-Json)
+  #Write-Debug (ConvertTo-Json -InputObject @{"linkedService" = $a} -Depth 50)
+  Write-Debug "END: Get-LinkedServiceBodyAzRestMethod()"
   return ConvertTo-Json -InputObject @{"linkedService" = $a} -Depth 50
 }
 
 
-function Test-LinkedServiceConnection([string]$LinkedServiceName, [string]$DataFactoryName, [string]$ResourceGroupName, [string]$BearerToken)
+function Test-LinkedServiceConnection(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $BearerToken, 
+  [string] $SubscriptionID,
+  $Params
+)
 {
+  Write-Debug "BEGIN: Test-LinkedServiceConnection()"
 
-  $body = Get-LinkedServiceBody -LinkedServiceName $LinkedServiceName -DataFactoryName $DataFactoryName -ResourceGroupName $ResourceGroupName -BearerToken $bearerToken
+  $body = Get-LinkedServiceBody -LinkedServiceName $LinkedServiceName -DataFactoryName $DataFactoryName -ResourceGroupName $ResourceGroupName -BearerToken $bearerToken -SubscriptionID $SubscriptionID
 
   $AzureEndpoint = "https://management.azure.com/subscriptions/$SubscriptionID/resourcegroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/testConnectivity?api-version=2018-06-01"
 
-  $params = @{
+  if ($Params) {
+    Write-Verbose "Found input parameters for this Linked Service, adding to the API request..."
+    $j = ConvertFrom-Json $body 
+    $j.linkedService.properties.parameters = $Params
+    $body = ConvertTo-Json -InputObject $j -Depth 50
+  }
+
+  Write-Verbose '============== Linked Service to being connection tested ============='
+  Write-Verbose $body
+  Write-Verbose '======================================================================'
+  
+  $request = @{
       ContentType = 'application/json'
       Headers = @{'accept'='application/json';'Authorization'=$BearerToken}
       Body = $Body
-      Method = 'Post'
+      Method = 'POST'
       Uri = $AzureEndpoint
   }
 
   try {
-    $response = Invoke-RestMethod @params
+    $response = Invoke-RestMethod @request
   }
   catch {
     Write-Error -Exception $_.Exception
   }
+  Write-Debug "END: Test-LinkedServiceConnection()"
   return $response
+}
+
+function Test-LinkedServiceConnectionAzRestMethod(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $SubscriptionID,
+  $Params
+)
+{
+  Write-Debug "BEGIN: Test-LinkedServiceConnectionAzRestMethod()"
+
+  $body = Get-LinkedServiceBodyAzRestMethod -LinkedServiceName $LinkedServiceName -DataFactoryName $DataFactoryName -ResourceGroupName $ResourceGroupName -SubscriptionID $SubscriptionID
+
+  $AzureEndpoint = "/subscriptions/$SubscriptionID/resourcegroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/testConnectivity?api-version=2018-06-01"
+
+  if ($Params) {
+    Write-Verbose "Found input parameters for this Linked Service, adding to the API request..."
+    $j = ConvertFrom-Json $body 
+    $j.linkedService.properties.parameters = $Params
+    $body = ConvertTo-Json -InputObject $j -Depth 50
+  }
+
+  $request = @{
+      Path = $AzureEndpoint
+      Payload = $Body
+      Method = 'POST'
+  }
+
+  try {
+    $response = Invoke-AzRestMethod @request
+  }
+  catch {
+    # Note: Invoke-AzRestMethod fails when payload indicates failure and error will be printed. Not fully feature parity with LinkedServiceConnection
+    Write-Error -Exception $_.Exception
+  }
+  Write-Debug "END: Test-LinkedServiceConnectionAzRestMethod()"
+  return ($response.Content | ConvertFrom-Json)
 }

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Update-GlobalParameters.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/private/Update-GlobalParameters.ps1
@@ -27,12 +27,10 @@ param
             }
             $targetAdf.GlobalParameters = $newGlobalParameters
 
-            # Write-Host "--- newGlobalParameters ---"
-            #$newGlobalParameters.Values | Out-Host
-
             if ($newGlobalParameters.Count -gt 0) {
                 Write-Verbose "Updating $($newGlobalParameters.Count) global parameters..."
-                Set-AzDataFactoryV2 -InputObject $targetAdf -Force | Out-Null
+                #Set-AzDataFactoryV2 -InputObject $targetAdf -Force | Out-Null
+                Set-GlobalParam($adf)
                 Write-Host "Update of $($newGlobalParameters.Count) global parameters complete."
             }
         }

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/public/Import-AdfFromFolder.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/public/Import-AdfFromFolder.ps1
@@ -37,7 +37,9 @@ function Import-AdfFromFolder {
 
     if ( !(Test-Path -Path $RootFolder) ) { Write-Error "ADFT0019: Folder '$RootFolder' doesn't exist." }
     
-    $adf.Location = $RootFolder
+    $adf.Location = Resolve-Path $RootFolder
+    $adf.PublishOptions = New-AdfPublishOption
+    Write-Verbose "Resolved RootFolder = $($adf.Location)"
 
     Import-AdfObjects -Adf $adf -All $adf.IntegrationRuntimes -RootFolder $RootFolder -SubFolder "integrationRuntime" | Out-Null
     Write-Host ("IntegrationRuntimes: {0} object(s) loaded." -f $adf.IntegrationRuntimes.Count)

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/public/New-AdfPublishOption.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/public/New-AdfPublishOption.ps1
@@ -45,6 +45,7 @@ function New-AdfPublishOption {
             Write-Error "ADFT0026: File does not exist: $FilterFilePath"
         }
         $FilterText = Get-Content -Path $FilterFilePath -Encoding "UTF8"
+        if ($null -eq $FilterText) { $FilterText = '' }
 
         $FilterArray = $FilterText.Replace(',', "`n").Replace("`r`n", "`n").Split("`n");
 

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2FromJson.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2FromJson.ps1
@@ -168,7 +168,7 @@ function Publish-AdfV2FromJson {
         }
 
         if ($null -eq $targetAdf) {
-            Write-Host "The process is exiting the function. Do fix the issue and run again."
+            Write-Host "ADFT0032: The process is exiting the function. Do fix the issue and run again."
             return 
         }
     }
@@ -304,12 +304,13 @@ function Publish-AdfV2FromJson {
         $adfIns.AllObjects() | ForEach-Object {
             Remove-AdfObjectIfNotInSource -adfSource $adf -adfTargetObj $_ -adfInstance $adfIns
         }
+        Write-Host "Deleted $($adf.DeletedObjectNames.Count) objects from ADF service."
     } else {
         Write-Host "Operation skipped as publish option 'DeleteNotInSource' = false"
     }
 
     Write-Host "===================================================================================";
-    Write-Host "STEP: Starting all triggers..."
+    Write-Host "STEP: Starting triggers..."
     if ($opt.StopStartTriggers -eq $true) {
         Start-Triggers -adf $adf
     } else {

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2UsingArm.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2UsingArm.ps1
@@ -124,7 +124,7 @@ function Publish-AdfV2UsingArm {
         }
 
         if ($null -eq $targetAdf) {
-            Write-Host "The process is exiting the function. Do fix the issue and run again."
+            Write-Host "ADFT0032: The process is exiting the function. Do fix the issue and run again."
             return 
         }
     }

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/public/Test-AdfCode.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/public/Test-AdfCode.ps1
@@ -86,8 +86,8 @@ function Test-AdfCode {
         }
     }
 
-    Write-Host "Checking names of datasets, pipelines, dataflows..."
-    $adf.LinkedServices + $adf.DataSets + $adf.Pipelines + $adf.DataFlows | ForEach-Object {
+    Write-Host "Checking names of linkedservices, datasets, dataflows..."
+    $adf.LinkedServices + $adf.DataSets + $adf.DataFlows | ForEach-Object {
         [string] $name = $_.Name
         if ($name.Contains('-')) {
             Write-Warning "Dashes ('-') are not allowed in the names of linked services, data flows, and datasets ($name)."

--- a/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/public/Test-AdfLinkedService.ps1
+++ b/deployAdfFromArmTask/ps_modules/azure.datafactory.tools/public/Test-AdfLinkedService.ps1
@@ -1,36 +1,89 @@
 function Test-AdfLinkedService {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'AzRestMethod')]
     param (
-        [parameter(Mandatory = $true)] 
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $LinkedServiceName,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $DataFactoryName,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $ResourceGroupName,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $SubscriptionID,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $TenantID,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $ClientID,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $ClientSecret
     )
+    Write-Debug "BEGIN: Test-AdfLinkedService(ParameterSetName = $($PSCmdlet.ParameterSetName))"
 
-    $bearerToken = Get-Bearer -TenantID $TenantID -ClientID $ClientID -ClientSecret $ClientSecret
+    if ($PSCmdlet.ParameterSetName -eq "ClientDetails") {
+        $bearerToken = Get-Bearer -TenantID $TenantID -ClientID $ClientID -ClientSecret $ClientSecret
+    }
+    $defFile = $false
+    if ($LinkedServiceName.EndsWith('.json'))
+    {
+        Write-Host "Definition of Linked Services in json file: $LinkedServiceName"
+        $definitionFile = Get-Content -Path $LinkedServiceName -Encoding utf8 -Raw
+        $j = $definitionFile | ConvertFrom-Json
+        $list = $j.linkedServices
+        Write-Host "Found $($list.Count) name(s) in definition file."
+        $defFile = $true
+    }
+    else {
+        $list = $LinkedServiceName.Split(',')
+        Write-Host "Found $($list.Count) name(s) in comma-separated list."
+    }
 
+    $report = @{}
     $all = 0
     $ok = 0
-    $LinkedServiceName.Split(',') | ForEach-Object { 
+    $list | ForEach-Object { 
         $all += 1
-        $ls = $_
-        Write-Host "Testing ADF Linked Service connection: [$_] ..." 
-        $r = Test-LinkedServiceConnection -LinkedServiceName $ls -DataFactoryName $DataFactoryName -ResourceGroup $ResourceGroupName -BearerToken $bearerToken
+        if ($defFile) { 
+            $ls = $_.name 
+            $params = $_.parameters
+        } 
+        else 
+        { 
+            $ls = $_ 
+            $params = $null
+        }
+        Write-Host "Testing ADF Linked Service connection: [$ls] ..." 
+        if ($PSCmdlet.ParameterSetName -eq "ClientDetails") {
+            $r = Test-LinkedServiceConnection -LinkedServiceName $ls `
+                -DataFactoryName $DataFactoryName `
+                -ResourceGroup $ResourceGroupName `
+                -BearerToken $bearerToken `
+                -SubscriptionID $SubscriptionID `
+                -Params $params
+        } else {
+            $r = Test-LinkedServiceConnectionAzRestMethod -LinkedServiceName $ls `
+                -DataFactoryName $DataFactoryName `
+                -ResourceGroup $ResourceGroupName `
+                -SubscriptionID $SubscriptionID `
+                -Params $params
+        }
+        $id = [String]::Format("{0:000}) {1}", $all, $ls)
         if ($null -ne $r -and $r.succeeded) {
-            Write-Host "[$_] : Connection successful."
+            Write-Host "$all) [$ls] : Connection successful."
+            $report.Add($id, $true)
             $ok += 1
         } else {
-            Write-Host "[$_] : Connection failed."
+            Write-Host "$all) [$ls] : Connection failed."
+            $report.Add($id, $false)
+            Write-Verbose ($r | ConvertTo-Json)
         }
     }
     
@@ -39,5 +92,8 @@ function Test-AdfLinkedService {
     Write-Host "Failed: $($all-$ok)"
     Write-Host "Total : $all"
 
+    Write-Debug "END: Test-AdfLinkedService()"
+    $result = [ordered]@{Passed = $ok; Failed = ($all-$ok); Total = $all; Report = $report}
+    return $result
 }
 

--- a/deployDataFactoryTask/PublishADF.ps1
+++ b/deployDataFactoryTask/PublishADF.ps1
@@ -67,6 +67,8 @@ try {
     [boolean]$DoNotDeleteExcludedObjects = Get-VstsInput -Name "DoNotDeleteExcludedObjects" -AsBool;
     [boolean]$IgnoreLackOfReferencedObject = Get-VstsInput -Name "IgnoreLackOfReferencedObject" -AsBool;
     [boolean]$IncrementalDeployment = Get-VstsInput -Name "IncrementalDeployment" -AsBool;
+    [string]$TriggerStopMethod = Get-VstsInput -Name "TriggerStopMethod";
+    [string]$TriggerStartMethod = Get-VstsInput -Name "TriggerStartMethod";
     #$input_pwsh = Get-VstsInput -Name 'pwsh' -AsBool
     
     $global:ErrorActionPreference = 'Stop';
@@ -91,6 +93,8 @@ try {
     $opt.DoNotDeleteExcludedObjects = $DoNotDeleteExcludedObjects
     $opt.IgnoreLackOfReferencedObject = $IgnoreLackOfReferencedObject
     $opt.IncrementalDeployment = $IncrementalDeployment
+    $opt.TriggerStopMethod = $TriggerStopMethod
+    $opt.TriggerStartMethod = $TriggerStartMethod
 
     # Validate the Filtering Type
     if ($FilteringType -ne "None") {

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/azure.datafactory.tools.psd1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/azure.datafactory.tools.psd1
@@ -12,7 +12,7 @@
     RootModule = 'azure.datafactory.tools.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.4.0'
+    ModuleVersion = '1.6.3'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/!AdfPublishOption.class.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/!AdfPublishOption.class.ps1
@@ -1,3 +1,15 @@
+enum TriggerStopTypes
+{
+    AllEnabled
+    DeployableOnly
+}
+
+enum TriggerStartTypes
+{
+    BasedOnSourceCode
+    KeepPreviousState
+}
+
 class AdfPublishOption {
     [hashtable] $Includes = @{}
     [hashtable] $Excludes = @{}
@@ -11,4 +23,6 @@ class AdfPublishOption {
     [Boolean] $DoNotStopStartExcludedTriggers = $false
     [Boolean] $DoNotDeleteExcludedObjects = $true
     [Boolean] $IncrementalDeployment = $false
+    [TriggerStopTypes] $TriggerStopMethod = [TriggerStopTypes]::AllEnabled
+    [TriggerStartTypes] $TriggerStartMethod = [TriggerStartTypes]::BasedOnSourceCode
 }

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Adf.class.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Adf.class.ps1
@@ -22,7 +22,10 @@ class Adf {
     [AdfGlobalProp] $GlobalFactory = [AdfGlobalProp]::new()
     [AdfPublishOption] $PublishOptions
     $ArmTemplateJson
-    
+    [System.Collections.ArrayList] $ActiveTriggers = @{}
+    [System.Collections.ArrayList] $DisabledTriggerNames = @{}
+    [System.Collections.ArrayList] $DeletedObjectNames = @{}
+
     [System.Collections.ArrayList] AllObjects()
     {
         return $this.LinkedServices + $this.Pipelines + $this.DataSets + $this.DataFlows + $this.Triggers + $this.IntegrationRuntimes + $this.Factories + $this.ManagedVirtualNetwork + $this.ManagedPrivateEndpoints + $this.Credentials
@@ -52,6 +55,16 @@ class Adf {
             }
         }
         return $r
+    }
+
+    [Boolean] IsObjectDeleted([string] $ObjectName)
+    {
+        return $this.DeletedObjectNames -contains $ObjectName
+    }
+
+    [Boolean] IsTriggerDisabled([string] $ObjectName)
+    {
+        return $this.DisabledTriggerNames -contains $ObjectName
     }
 
     [System.Collections.ArrayList] GetUnusedDatasets()

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Get-AdfObjectByPattern.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Get-AdfObjectByPattern.ps1
@@ -48,6 +48,10 @@ function Get-AdfObjectByPattern {
         {
             $r = $adf.ManagedPrivateEndpoints | Where-Object { $_.Name -like $name }
         }
+        'Credential'
+        {
+            $r = $adf.Credentials | Where-Object { $_.Name -like $name }
+        }
         default
         {
             Write-Error "ADFT0015: Type [$type] is not supported."

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/GlobalParam.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/GlobalParam.ps1
@@ -24,13 +24,17 @@ function Get-GlobalParam([string]$ResourceGroupName, [string]$DataFactoryName)
   }
   catch {
     Write-Error -Exception $_.Exception
+    $response = ""  # Workaround when ADF service returns error 404 for newly created ADF
   }
   return $response
 }
 
 
-function Set-GlobalParam([string]$ResourceGroupName, [string]$DataFactoryName, $value)
+function Set-GlobalParam([Adf] $adf)
 {
+  $ResourceGroupName = $adf.ResourceGroupName
+  $DataFactoryName = $adf.Name
+
   $azContext = Get-AzContext
   [string] $SubscriptionID = $azContext.Subscription.Id
   $azProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
@@ -41,8 +45,10 @@ function Set-GlobalParam([string]$ResourceGroupName, [string]$DataFactoryName, $
       'Authorization'='Bearer ' + $token.AccessToken
   }
 
+  $gp = ($adf.GlobalFactory.body | ConvertFrom-Json).properties.globalParameters | ConvertTo-Json -Depth 50
+
   $body = "{
-    ""properties"": { ""adftools_deployment_state"": { ""value"": ""$value AJHIUHWIUI"", ""type"": ""Object"" }  }
+    ""properties"": $gp
   }"
 
   $restUri = "https://management.azure.com/subscriptions/$SubscriptionID/resourcegroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/globalParameters/default?api-version=2018-06-01"

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/ObjectProperty.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/ObjectProperty.ps1
@@ -25,7 +25,9 @@ function Update-ObjectProperty {
         $exp = "`$obj.$path = `$$value"
     } elseif ($fieldType -eq [DateTime]) {
         Write-Debug "Setting as DateTime value"
-        $exp = "`$obj.$path = `"$value`""
+        $datevalue = [DateTime]$value
+        $utcvalue = Get-Date $datevalue -Format "yyyy-MM-ddTHH:mm:ss.fffZ"
+        $exp = "`$obj.$path = `"$utcvalue`""
     } elseif ($fieldType -eq [System.Management.Automation.PSCustomObject]) {
         Write-Debug "Setting as json value"
         $jvalue = ConvertFrom-Json $value

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObject.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObject.ps1
@@ -68,6 +68,15 @@ function Remove-AdfObject {
                     -Force -ErrorVariable err -ErrorAction Stop | Out-Null
             }
             "Trigger" {
+                # Stop trigger if enabled before delete it
+                if ($obj.RuntimeState -eq 'Started') {
+                    Write-Verbose "Disabling trigger: $name..." 
+                    Stop-AzDataFactoryV2Trigger `
+                        -ResourceGroupName $ResourceGroupName `
+                        -DataFactoryName $DataFactoryName `
+                        -Name $name `
+                        -Force -ErrorVariable err -ErrorAction Stop | Out-Null
+                }
                 Remove-AzDataFactoryV2Trigger `
                     -ResourceGroupName $ResourceGroupName `
                     -DataFactoryName $DataFactoryName `
@@ -79,7 +88,7 @@ function Remove-AdfObject {
                     -type_plural 'credentials' `
                     -name $name `
                     -adfInstance $adfInstance `
-                    -Force -ErrorVariable err -ErrorAction Stop | Out-Null
+                    -ErrorVariable err -ErrorAction Stop | Out-Null
             }
             "DoNothing" {
 

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObjectIfNotInSource.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObjectIfNotInSource.ps1
@@ -16,6 +16,7 @@ function Remove-AdfObjectIfNotInSource {
     {
         Write-Verbose "Object [$simtype].[$name] hasn't been found in the source - to be deleted."
         Remove-AdfObject -adfSource $adfSource -obj $adfTargetObj -adfInstance $adfInstance
+        $adf.DeletedObjectNames.Add("$type.$name")
     }
     else {
         Write-Verbose "Object [$simtype].[$name] is in the source - won't be delete."

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Save-AdfObjectAsFile.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Save-AdfObjectAsFile.ps1
@@ -4,7 +4,13 @@ function Save-AdfObjectAsFile {
         [parameter(Mandatory = $true)] [AdfObject] $obj
     )
     
-    $newFileName = Join-Path $obj.Adf.Location "$($obj.Type)\~$($obj.Name).json"
+    $folder = Join-Path -Path $obj.Adf.Location -ChildPath $($obj.Type)
+    if (!(Test-Path $folder)) { 
+        Write-Debug "Creating a folder: $folder"
+        New-Item -Path $folder -ItemType Directory | Out-Null
+    }
+
+    $newFileName = Join-Path -Path $folder -ChildPath "~$($obj.Name).json"
     Write-Debug "Writing file: $newFileName"
 
     $output = ($obj.Body | ConvertTo-Json -Compress:$true -Depth 100)

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Start-Trigger.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Start-Trigger.ps1
@@ -7,6 +7,7 @@ function Start-Trigger {
     )
     Write-Debug "BEGIN: Start-Trigger()"
 
+    Write-Host "- Enabling trigger: $Name"
     $attempts = 5;
     $i = 0
     while ($i -lt $attempts)

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Start-Triggers.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Start-Triggers.ps1
@@ -5,24 +5,60 @@ function Start-Triggers {
     )
     Write-Debug "BEGIN: Start-Triggers()"
 
-    [AdfObject[]] $activeTrigger = $adf.Triggers `
-    | Where-Object { $_.Body.properties.runtimeState -eq "Started" } | ToArray
-    Write-Host ("The number of triggers to start: " + $activeTrigger.Count)
+    Write-Host ("TriggerStartMethod = $($adf.PublishOptions.TriggerStartMethod)")
 
-    #Start active triggers - after cleanup efforts
-    $activeTrigger | ForEach-Object { 
-        Write-Host "- Enabling trigger: $($_.Name)"
-        [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$($_.Name)")
-        $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
-        if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
-            Write-host "- Excluded trigger: $($_.Name)" 
-        } else {
+    # Determine triggers to be started
+    if ($adf.PublishOptions.TriggerStartMethod -eq 'KeepPreviousState') {
+        $activeTriggers = $adf.ActiveTriggers | ToArray
+    } else {
+        $activeTriggers = $adf.Triggers `
+        | Where-Object { $_.Body.properties.runtimeState -eq "Started" } | ToArray
+    }
+
+    [System.Collections.ArrayList] $toBeStarted = @{}
+    if ($null -ne $activeTriggers -and $activeTriggers.Count -gt 0)
+    {
+        $activeTriggers | ForEach-Object { 
+            $isStart = $true
+            $triggerName = $_.Name
+            [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$triggerName")
+            # Check whether a trigger is excluded
+            $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
+            if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
+                Write-Host "- Excluded trigger: $triggerName" 
+                $isStart = $false
+            } 
+            # Check whether a trigger has been deleted
+            if ($isStart -and $adf.IsObjectDeleted("trigger.$triggerName")) {
+                Write-Host "- Deleted trigger: $triggerName" 
+                $isStart = $false
+            }
+            # Check whether a trigger has not been stopped    #-and $adf.PublishOptions.TriggerStartMethod -eq 'BasedOnSourceCode' `
+            if ($isStart -and $adf.PublishOptions.TriggerStopMethod  -eq 'DeployableOnly' `
+                         -and $adf.IsTriggerDisabled("$triggerName") -eq $false) {
+                Write-Host "- Trigger already started: $triggerName" 
+                $isStart = $false
+            }
+            if ($isStart) {
+                $toBeStarted.Add($triggerName) | Out-Null
+            }
+        }
+    }
+
+    Write-Host ("The number of triggers to start: " + $toBeStarted.Count)
+
+    # Start triggers
+    if ($toBeStarted.Count -gt 0)
+    {
+        Write-Host "Starting triggers:"
+        $toBeStarted | ForEach-Object { 
             Start-Trigger `
             -ResourceGroupName $adf.ResourceGroupName `
             -DataFactoryName $adf.Name `
-            -Name $_.Name `
+            -Name $_ `
             | Out-Null
         }
+        Write-Host "Complete starting triggers."
     }
 
     Write-Debug "END: Start-Triggers()"

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Stop-Triggers.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Stop-Triggers.ps1
@@ -10,30 +10,61 @@ function Stop-Triggers {
     if ($null -ne $triggersADF) 
     {
         # Goal: Stop all active triggers (<>Stopped) present in ADF service
-        $triggersToStop = $triggersADF | Where-Object { $_.RuntimeState -ne "Stopped" } | ToArray
+        $activeTriggers = $triggersADF | Where-Object { $_.RuntimeState -ne "Stopped" } | ToArray
+        $adf.activeTriggers = $activeTriggers       # Remember to use after the deployment when TriggerStartMethod = 'KeepPreviousState'
         $allAdfTriggersArray = $triggersADF | ToArray
-        Write-Host ("The number of triggers to stop: " + $triggersToStop.Count + " (out of $($allAdfTriggersArray.Count))")
+        Write-Host ("The number of active triggers: " + $activeTriggers.Count + " (out of $($allAdfTriggersArray.Count))")
+        Write-Host ("TriggerStopMethod = $($adf.PublishOptions.TriggerStopMethod)")
 
-        #Stop all triggers
-        if ($null -ne $triggersToStop -and $triggersToStop.Count -gt 0)
+        # Determine triggers to be stopped
+        [System.Collections.ArrayList] $toBeStopped = @{}
+        if ($null -ne $activeTriggers -and $activeTriggers.Count -gt 0)
         {
-            Write-Host "Stopping deployed triggers:"
-            $triggersToStop | ForEach-Object { 
-                [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$($_.Name)")
-                $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
-                if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
-                    Write-host "- Excluded trigger: $($_.Name)" 
-                } else {
-                    Stop-Trigger `
-                    -ResourceGroupName $adf.ResourceGroupName `
-                    -DataFactoryName $adf.Name `
-                    -Name $_.Name `
-                    | Out-Null
+            $activeTriggers | ForEach-Object { 
+                $deploy = $true
+                $triggerName = $_.Name
+                [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$triggerName")
+                # Check whether a trigger is not for deployment
+                if ($adf.PublishOptions.TriggerStopMethod -eq 'DeployableOnly') {
+                    $sourceObject = Get-AdfObjectByName -adf $adf -name $triggerName -type 'Trigger'
+                    if ($null -eq $sourceObject -or $sourceObject.ToBeDeployed -eq $false) {
+                        Write-Host "- Ignored trigger: $triggerName"
+                        $deploy = $false
+                    }
+                }
+                # Check whether a trigger is excluded
+                if ($deploy) {
+                    $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
+                    if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
+                        Write-Host "- Excluded trigger: $triggerName"
+                        $deploy = $false
+                    } 
+                }
+                if ($deploy) {
+                    $toBeStopped.Add($triggerName) | Out-Null
                 }
             }
-            Write-Host "Complete stopping deployed triggers"
         }
+        Write-Host ("The number of triggers to stop: " + $toBeStopped.Count)
 
+        # Stop triggers
+        if ($toBeStopped.Count -gt 0)
+        {
+            Write-Host "Stopping deployed triggers:"
+            $toBeStopped | ForEach-Object { 
+                Stop-Trigger `
+                -ResourceGroupName $adf.ResourceGroupName `
+                -DataFactoryName $adf.Name `
+                -Name $_ `
+                | Out-Null
+            }
+            Write-Host "Complete stopping deployed triggers."
+        }
+        $adf.DisabledTriggerNames = $toBeStopped
+    }
+    else 
+    {
+        Write-Host ("No remote triggers found.")
     }
 
     Write-Debug "END: Stop-Triggers()"

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Test-LinkedServiceConnection.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Test-LinkedServiceConnection.ps1
@@ -2,7 +2,11 @@
 # https://datathirst.net/blog/2018/9/23/adfv2-testing-linked-services
 
 
-function Get-Bearer([string]$TenantID, [string]$ClientID, [string]$ClientSecret)
+function Get-Bearer(
+  [string] $TenantID, 
+  [string] $ClientID, 
+  [string] $ClientSecret
+)
 {
   $TokenEndpoint = {https://login.windows.net/{0}/oauth2/token} -f $TenantID 
   $ARMResource = "https://management.core.windows.net/";
@@ -14,7 +18,7 @@ function Get-Bearer([string]$TenantID, [string]$ClientID, [string]$ClientSecret)
           'client_secret' = $ClientSecret
   }
 
-  $params = @{
+  $request = @{
       ContentType = 'application/x-www-form-urlencoded'
       Headers = @{'accept'='application/json'}
       Body = $Body
@@ -22,48 +26,138 @@ function Get-Bearer([string]$TenantID, [string]$ClientID, [string]$ClientSecret)
       URI = $TokenEndpoint
   }
 
-  $token = Invoke-RestMethod @params
+  $token = Invoke-RestMethod @request
 
   return "Bearer " + ($token.access_token).ToString()
 }
 
 
-function Get-LinkedServiceBody([string]$LinkedServiceName, [string]$DataFactoryName, [string]$ResourceGroupName, [string]$BearerToken)
+function Get-LinkedServiceBody(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $BearerToken, 
+  [string] $SubscriptionID
+)
 {
+  Write-Debug "BEGIN: Get-LinkedServiceBody()"
   $ADFEndpoint = "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/linkedservices/$($LinkedServiceName)?api-version=2018-06-01"
 
-  $params = @{
+  $request = @{
       ContentType = 'application/json'
       Headers = @{'accept'='application/json';'Authorization'=$BearerToken}
       Method = 'GET'
       URI = $ADFEndpoint
   }
 
-  $a = Invoke-RestMethod @params
+  $a = Invoke-RestMethod @request
+  Write-Debug "END: Get-LinkedServiceBody()"
+  return ConvertTo-Json -InputObject @{"linkedService" = $a} -Depth 50
+}
+
+function Get-LinkedServiceBodyAzRestMethod(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $SubscriptionID,
+  $Params
+)
+{
+  Write-Debug "BEGIN: Get-LinkedServiceBodyAzRestMethod()"
+
+  $ADFEndpoint = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/linkedservices/$($LinkedServiceName)?api-version=2018-06-01"
+
+  $request = @{
+      Path = $ADFEndpoint
+      Method = 'GET'
+  }
+
+  $a = Invoke-AzRestMethod @request
+  $a = ($a.Content | ConvertFrom-Json)
+  #Write-Debug (ConvertTo-Json -InputObject @{"linkedService" = $a} -Depth 50)
+  Write-Debug "END: Get-LinkedServiceBodyAzRestMethod()"
   return ConvertTo-Json -InputObject @{"linkedService" = $a} -Depth 50
 }
 
 
-function Test-LinkedServiceConnection([string]$LinkedServiceName, [string]$DataFactoryName, [string]$ResourceGroupName, [string]$BearerToken)
+function Test-LinkedServiceConnection(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $BearerToken, 
+  [string] $SubscriptionID,
+  $Params
+)
 {
+  Write-Debug "BEGIN: Test-LinkedServiceConnection()"
 
-  $body = Get-LinkedServiceBody -LinkedServiceName $LinkedServiceName -DataFactoryName $DataFactoryName -ResourceGroupName $ResourceGroupName -BearerToken $bearerToken
+  $body = Get-LinkedServiceBody -LinkedServiceName $LinkedServiceName -DataFactoryName $DataFactoryName -ResourceGroupName $ResourceGroupName -BearerToken $bearerToken -SubscriptionID $SubscriptionID
 
   $AzureEndpoint = "https://management.azure.com/subscriptions/$SubscriptionID/resourcegroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/testConnectivity?api-version=2018-06-01"
 
-  $params = @{
+  if ($Params) {
+    Write-Verbose "Found input parameters for this Linked Service, adding to the API request..."
+    $j = ConvertFrom-Json $body 
+    $j.linkedService.properties.parameters = $Params
+    $body = ConvertTo-Json -InputObject $j -Depth 50
+  }
+
+  Write-Verbose '============== Linked Service to being connection tested ============='
+  Write-Verbose $body
+  Write-Verbose '======================================================================'
+  
+  $request = @{
       ContentType = 'application/json'
       Headers = @{'accept'='application/json';'Authorization'=$BearerToken}
       Body = $Body
-      Method = 'Post'
+      Method = 'POST'
       Uri = $AzureEndpoint
   }
 
   try {
-    $response = Invoke-RestMethod @params
+    $response = Invoke-RestMethod @request
   }
   catch {
     Write-Error -Exception $_.Exception
   }
+  Write-Debug "END: Test-LinkedServiceConnection()"
   return $response
+}
+
+function Test-LinkedServiceConnectionAzRestMethod(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $SubscriptionID,
+  $Params
+)
+{
+  Write-Debug "BEGIN: Test-LinkedServiceConnectionAzRestMethod()"
+
+  $body = Get-LinkedServiceBodyAzRestMethod -LinkedServiceName $LinkedServiceName -DataFactoryName $DataFactoryName -ResourceGroupName $ResourceGroupName -SubscriptionID $SubscriptionID
+
+  $AzureEndpoint = "/subscriptions/$SubscriptionID/resourcegroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/testConnectivity?api-version=2018-06-01"
+
+  if ($Params) {
+    Write-Verbose "Found input parameters for this Linked Service, adding to the API request..."
+    $j = ConvertFrom-Json $body 
+    $j.linkedService.properties.parameters = $Params
+    $body = ConvertTo-Json -InputObject $j -Depth 50
+  }
+
+  $request = @{
+      Path = $AzureEndpoint
+      Payload = $Body
+      Method = 'POST'
+  }
+
+  try {
+    $response = Invoke-AzRestMethod @request
+  }
+  catch {
+    # Note: Invoke-AzRestMethod fails when payload indicates failure and error will be printed. Not fully feature parity with LinkedServiceConnection
+    Write-Error -Exception $_.Exception
+  }
+  Write-Debug "END: Test-LinkedServiceConnectionAzRestMethod()"
+  return ($response.Content | ConvertFrom-Json)
 }

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Update-GlobalParameters.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/private/Update-GlobalParameters.ps1
@@ -27,12 +27,10 @@ param
             }
             $targetAdf.GlobalParameters = $newGlobalParameters
 
-            # Write-Host "--- newGlobalParameters ---"
-            #$newGlobalParameters.Values | Out-Host
-
             if ($newGlobalParameters.Count -gt 0) {
                 Write-Verbose "Updating $($newGlobalParameters.Count) global parameters..."
-                Set-AzDataFactoryV2 -InputObject $targetAdf -Force | Out-Null
+                #Set-AzDataFactoryV2 -InputObject $targetAdf -Force | Out-Null
+                Set-GlobalParam($adf)
                 Write-Host "Update of $($newGlobalParameters.Count) global parameters complete."
             }
         }

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/public/Import-AdfFromFolder.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/public/Import-AdfFromFolder.ps1
@@ -37,7 +37,9 @@ function Import-AdfFromFolder {
 
     if ( !(Test-Path -Path $RootFolder) ) { Write-Error "ADFT0019: Folder '$RootFolder' doesn't exist." }
     
-    $adf.Location = $RootFolder
+    $adf.Location = Resolve-Path $RootFolder
+    $adf.PublishOptions = New-AdfPublishOption
+    Write-Verbose "Resolved RootFolder = $($adf.Location)"
 
     Import-AdfObjects -Adf $adf -All $adf.IntegrationRuntimes -RootFolder $RootFolder -SubFolder "integrationRuntime" | Out-Null
     Write-Host ("IntegrationRuntimes: {0} object(s) loaded." -f $adf.IntegrationRuntimes.Count)

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/public/New-AdfPublishOption.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/public/New-AdfPublishOption.ps1
@@ -45,6 +45,7 @@ function New-AdfPublishOption {
             Write-Error "ADFT0026: File does not exist: $FilterFilePath"
         }
         $FilterText = Get-Content -Path $FilterFilePath -Encoding "UTF8"
+        if ($null -eq $FilterText) { $FilterText = '' }
 
         $FilterArray = $FilterText.Replace(',', "`n").Replace("`r`n", "`n").Split("`n");
 

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2FromJson.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2FromJson.ps1
@@ -168,7 +168,7 @@ function Publish-AdfV2FromJson {
         }
 
         if ($null -eq $targetAdf) {
-            Write-Host "The process is exiting the function. Do fix the issue and run again."
+            Write-Host "ADFT0032: The process is exiting the function. Do fix the issue and run again."
             return 
         }
     }
@@ -304,12 +304,13 @@ function Publish-AdfV2FromJson {
         $adfIns.AllObjects() | ForEach-Object {
             Remove-AdfObjectIfNotInSource -adfSource $adf -adfTargetObj $_ -adfInstance $adfIns
         }
+        Write-Host "Deleted $($adf.DeletedObjectNames.Count) objects from ADF service."
     } else {
         Write-Host "Operation skipped as publish option 'DeleteNotInSource' = false"
     }
 
     Write-Host "===================================================================================";
-    Write-Host "STEP: Starting all triggers..."
+    Write-Host "STEP: Starting triggers..."
     if ($opt.StopStartTriggers -eq $true) {
         Start-Triggers -adf $adf
     } else {

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2UsingArm.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2UsingArm.ps1
@@ -124,7 +124,7 @@ function Publish-AdfV2UsingArm {
         }
 
         if ($null -eq $targetAdf) {
-            Write-Host "The process is exiting the function. Do fix the issue and run again."
+            Write-Host "ADFT0032: The process is exiting the function. Do fix the issue and run again."
             return 
         }
     }

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/public/Test-AdfCode.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/public/Test-AdfCode.ps1
@@ -86,8 +86,8 @@ function Test-AdfCode {
         }
     }
 
-    Write-Host "Checking names of datasets, pipelines, dataflows..."
-    $adf.LinkedServices + $adf.DataSets + $adf.Pipelines + $adf.DataFlows | ForEach-Object {
+    Write-Host "Checking names of linkedservices, datasets, dataflows..."
+    $adf.LinkedServices + $adf.DataSets + $adf.DataFlows | ForEach-Object {
         [string] $name = $_.Name
         if ($name.Contains('-')) {
             Write-Warning "Dashes ('-') are not allowed in the names of linked services, data flows, and datasets ($name)."

--- a/deployDataFactoryTask/ps_modules/azure.datafactory.tools/public/Test-AdfLinkedService.ps1
+++ b/deployDataFactoryTask/ps_modules/azure.datafactory.tools/public/Test-AdfLinkedService.ps1
@@ -1,36 +1,89 @@
 function Test-AdfLinkedService {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'AzRestMethod')]
     param (
-        [parameter(Mandatory = $true)] 
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $LinkedServiceName,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $DataFactoryName,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $ResourceGroupName,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $SubscriptionID,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $TenantID,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $ClientID,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $ClientSecret
     )
+    Write-Debug "BEGIN: Test-AdfLinkedService(ParameterSetName = $($PSCmdlet.ParameterSetName))"
 
-    $bearerToken = Get-Bearer -TenantID $TenantID -ClientID $ClientID -ClientSecret $ClientSecret
+    if ($PSCmdlet.ParameterSetName -eq "ClientDetails") {
+        $bearerToken = Get-Bearer -TenantID $TenantID -ClientID $ClientID -ClientSecret $ClientSecret
+    }
+    $defFile = $false
+    if ($LinkedServiceName.EndsWith('.json'))
+    {
+        Write-Host "Definition of Linked Services in json file: $LinkedServiceName"
+        $definitionFile = Get-Content -Path $LinkedServiceName -Encoding utf8 -Raw
+        $j = $definitionFile | ConvertFrom-Json
+        $list = $j.linkedServices
+        Write-Host "Found $($list.Count) name(s) in definition file."
+        $defFile = $true
+    }
+    else {
+        $list = $LinkedServiceName.Split(',')
+        Write-Host "Found $($list.Count) name(s) in comma-separated list."
+    }
 
+    $report = @{}
     $all = 0
     $ok = 0
-    $LinkedServiceName.Split(',') | ForEach-Object { 
+    $list | ForEach-Object { 
         $all += 1
-        $ls = $_
-        Write-Host "Testing ADF Linked Service connection: [$_] ..." 
-        $r = Test-LinkedServiceConnection -LinkedServiceName $ls -DataFactoryName $DataFactoryName -ResourceGroup $ResourceGroupName -BearerToken $bearerToken
+        if ($defFile) { 
+            $ls = $_.name 
+            $params = $_.parameters
+        } 
+        else 
+        { 
+            $ls = $_ 
+            $params = $null
+        }
+        Write-Host "Testing ADF Linked Service connection: [$ls] ..." 
+        if ($PSCmdlet.ParameterSetName -eq "ClientDetails") {
+            $r = Test-LinkedServiceConnection -LinkedServiceName $ls `
+                -DataFactoryName $DataFactoryName `
+                -ResourceGroup $ResourceGroupName `
+                -BearerToken $bearerToken `
+                -SubscriptionID $SubscriptionID `
+                -Params $params
+        } else {
+            $r = Test-LinkedServiceConnectionAzRestMethod -LinkedServiceName $ls `
+                -DataFactoryName $DataFactoryName `
+                -ResourceGroup $ResourceGroupName `
+                -SubscriptionID $SubscriptionID `
+                -Params $params
+        }
+        $id = [String]::Format("{0:000}) {1}", $all, $ls)
         if ($null -ne $r -and $r.succeeded) {
-            Write-Host "[$_] : Connection successful."
+            Write-Host "$all) [$ls] : Connection successful."
+            $report.Add($id, $true)
             $ok += 1
         } else {
-            Write-Host "[$_] : Connection failed."
+            Write-Host "$all) [$ls] : Connection failed."
+            $report.Add($id, $false)
+            Write-Verbose ($r | ConvertTo-Json)
         }
     }
     
@@ -39,5 +92,8 @@ function Test-AdfLinkedService {
     Write-Host "Failed: $($all-$ok)"
     Write-Host "Total : $all"
 
+    Write-Debug "END: Test-AdfLinkedService()"
+    $result = [ordered]@{Passed = $ok; Failed = ($all-$ok); Total = $all; Report = $report}
+    return $result
 }
 

--- a/deployDataFactoryTask/task.json
+++ b/deployDataFactoryTask/task.json
@@ -216,6 +216,32 @@
             "helpMarkDown": "Usually, the deployment will fail if a resource is referenced that's not present in a JSON file. Set to *True* to warn instead of failing.",
             "groupname": "advanced",
             "required": false
+        },
+        {
+            "name": "TriggerStopMethod",
+            "type": "pickList",
+            "label": "Triggers: Stop Method",
+            "required": false,
+            "defaultValue": "AllEnabled",
+            "options": {
+                "AllEnabled": "All Enabled (default)",
+                "DeployableOnly": "Deployable Only"
+            },
+            "helpMarkDown": "Indicates how many triggers should be stopped before the deployment. \n[Read more...](https://github.com/Azure-Player/azure.datafactory.tools#step-stoping-triggers)",
+            "groupName": "advanced"
+        },
+        {
+            "name": "TriggerStartMethod",
+            "type": "pickList",
+            "label": "Triggers: Start Method",
+            "required": false,
+            "defaultValue": "BasedOnSourceCode",
+            "options": {
+                "BasedOnSourceCode": "Based On Source Code (default)",
+                "KeepPreviousState": "Keep Previous State"
+            },
+            "helpMarkDown": "Indicates which triggers should be started after the deployment. \n[Read more...](https://github.com/Azure-Player/azure.datafactory.tools#step-restarting-triggers)",
+            "groupName": "advanced"
         }
     ],
     "dataSourceBindings": [

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/azure.datafactory.tools.psd1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/azure.datafactory.tools.psd1
@@ -12,7 +12,7 @@
     RootModule = 'azure.datafactory.tools.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.4.0'
+    ModuleVersion = '1.6.3'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/!AdfPublishOption.class.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/!AdfPublishOption.class.ps1
@@ -1,3 +1,15 @@
+enum TriggerStopTypes
+{
+    AllEnabled
+    DeployableOnly
+}
+
+enum TriggerStartTypes
+{
+    BasedOnSourceCode
+    KeepPreviousState
+}
+
 class AdfPublishOption {
     [hashtable] $Includes = @{}
     [hashtable] $Excludes = @{}
@@ -11,4 +23,6 @@ class AdfPublishOption {
     [Boolean] $DoNotStopStartExcludedTriggers = $false
     [Boolean] $DoNotDeleteExcludedObjects = $true
     [Boolean] $IncrementalDeployment = $false
+    [TriggerStopTypes] $TriggerStopMethod = [TriggerStopTypes]::AllEnabled
+    [TriggerStartTypes] $TriggerStartMethod = [TriggerStartTypes]::BasedOnSourceCode
 }

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Adf.class.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Adf.class.ps1
@@ -22,7 +22,10 @@ class Adf {
     [AdfGlobalProp] $GlobalFactory = [AdfGlobalProp]::new()
     [AdfPublishOption] $PublishOptions
     $ArmTemplateJson
-    
+    [System.Collections.ArrayList] $ActiveTriggers = @{}
+    [System.Collections.ArrayList] $DisabledTriggerNames = @{}
+    [System.Collections.ArrayList] $DeletedObjectNames = @{}
+
     [System.Collections.ArrayList] AllObjects()
     {
         return $this.LinkedServices + $this.Pipelines + $this.DataSets + $this.DataFlows + $this.Triggers + $this.IntegrationRuntimes + $this.Factories + $this.ManagedVirtualNetwork + $this.ManagedPrivateEndpoints + $this.Credentials
@@ -52,6 +55,16 @@ class Adf {
             }
         }
         return $r
+    }
+
+    [Boolean] IsObjectDeleted([string] $ObjectName)
+    {
+        return $this.DeletedObjectNames -contains $ObjectName
+    }
+
+    [Boolean] IsTriggerDisabled([string] $ObjectName)
+    {
+        return $this.DisabledTriggerNames -contains $ObjectName
     }
 
     [System.Collections.ArrayList] GetUnusedDatasets()

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Get-AdfObjectByPattern.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Get-AdfObjectByPattern.ps1
@@ -48,6 +48,10 @@ function Get-AdfObjectByPattern {
         {
             $r = $adf.ManagedPrivateEndpoints | Where-Object { $_.Name -like $name }
         }
+        'Credential'
+        {
+            $r = $adf.Credentials | Where-Object { $_.Name -like $name }
+        }
         default
         {
             Write-Error "ADFT0015: Type [$type] is not supported."

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/GlobalParam.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/GlobalParam.ps1
@@ -24,13 +24,17 @@ function Get-GlobalParam([string]$ResourceGroupName, [string]$DataFactoryName)
   }
   catch {
     Write-Error -Exception $_.Exception
+    $response = ""  # Workaround when ADF service returns error 404 for newly created ADF
   }
   return $response
 }
 
 
-function Set-GlobalParam([string]$ResourceGroupName, [string]$DataFactoryName, $value)
+function Set-GlobalParam([Adf] $adf)
 {
+  $ResourceGroupName = $adf.ResourceGroupName
+  $DataFactoryName = $adf.Name
+
   $azContext = Get-AzContext
   [string] $SubscriptionID = $azContext.Subscription.Id
   $azProfile = [Microsoft.Azure.Commands.Common.Authentication.Abstractions.AzureRmProfileProvider]::Instance.Profile
@@ -41,8 +45,10 @@ function Set-GlobalParam([string]$ResourceGroupName, [string]$DataFactoryName, $
       'Authorization'='Bearer ' + $token.AccessToken
   }
 
+  $gp = ($adf.GlobalFactory.body | ConvertFrom-Json).properties.globalParameters | ConvertTo-Json -Depth 50
+
   $body = "{
-    ""properties"": { ""adftools_deployment_state"": { ""value"": ""$value AJHIUHWIUI"", ""type"": ""Object"" }  }
+    ""properties"": $gp
   }"
 
   $restUri = "https://management.azure.com/subscriptions/$SubscriptionID/resourcegroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/globalParameters/default?api-version=2018-06-01"

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/ObjectProperty.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/ObjectProperty.ps1
@@ -25,7 +25,9 @@ function Update-ObjectProperty {
         $exp = "`$obj.$path = `$$value"
     } elseif ($fieldType -eq [DateTime]) {
         Write-Debug "Setting as DateTime value"
-        $exp = "`$obj.$path = `"$value`""
+        $datevalue = [DateTime]$value
+        $utcvalue = Get-Date $datevalue -Format "yyyy-MM-ddTHH:mm:ss.fffZ"
+        $exp = "`$obj.$path = `"$utcvalue`""
     } elseif ($fieldType -eq [System.Management.Automation.PSCustomObject]) {
         Write-Debug "Setting as json value"
         $jvalue = ConvertFrom-Json $value

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObject.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObject.ps1
@@ -68,6 +68,15 @@ function Remove-AdfObject {
                     -Force -ErrorVariable err -ErrorAction Stop | Out-Null
             }
             "Trigger" {
+                # Stop trigger if enabled before delete it
+                if ($obj.RuntimeState -eq 'Started') {
+                    Write-Verbose "Disabling trigger: $name..." 
+                    Stop-AzDataFactoryV2Trigger `
+                        -ResourceGroupName $ResourceGroupName `
+                        -DataFactoryName $DataFactoryName `
+                        -Name $name `
+                        -Force -ErrorVariable err -ErrorAction Stop | Out-Null
+                }
                 Remove-AzDataFactoryV2Trigger `
                     -ResourceGroupName $ResourceGroupName `
                     -DataFactoryName $DataFactoryName `
@@ -79,7 +88,7 @@ function Remove-AdfObject {
                     -type_plural 'credentials' `
                     -name $name `
                     -adfInstance $adfInstance `
-                    -Force -ErrorVariable err -ErrorAction Stop | Out-Null
+                    -ErrorVariable err -ErrorAction Stop | Out-Null
             }
             "DoNothing" {
 

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObjectIfNotInSource.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Remove-AdfObjectIfNotInSource.ps1
@@ -16,6 +16,7 @@ function Remove-AdfObjectIfNotInSource {
     {
         Write-Verbose "Object [$simtype].[$name] hasn't been found in the source - to be deleted."
         Remove-AdfObject -adfSource $adfSource -obj $adfTargetObj -adfInstance $adfInstance
+        $adf.DeletedObjectNames.Add("$type.$name")
     }
     else {
         Write-Verbose "Object [$simtype].[$name] is in the source - won't be delete."

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Save-AdfObjectAsFile.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Save-AdfObjectAsFile.ps1
@@ -4,7 +4,13 @@ function Save-AdfObjectAsFile {
         [parameter(Mandatory = $true)] [AdfObject] $obj
     )
     
-    $newFileName = Join-Path $obj.Adf.Location "$($obj.Type)\~$($obj.Name).json"
+    $folder = Join-Path -Path $obj.Adf.Location -ChildPath $($obj.Type)
+    if (!(Test-Path $folder)) { 
+        Write-Debug "Creating a folder: $folder"
+        New-Item -Path $folder -ItemType Directory | Out-Null
+    }
+
+    $newFileName = Join-Path -Path $folder -ChildPath "~$($obj.Name).json"
     Write-Debug "Writing file: $newFileName"
 
     $output = ($obj.Body | ConvertTo-Json -Compress:$true -Depth 100)

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Start-Trigger.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Start-Trigger.ps1
@@ -7,6 +7,7 @@ function Start-Trigger {
     )
     Write-Debug "BEGIN: Start-Trigger()"
 
+    Write-Host "- Enabling trigger: $Name"
     $attempts = 5;
     $i = 0
     while ($i -lt $attempts)

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Start-Triggers.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Start-Triggers.ps1
@@ -5,24 +5,60 @@ function Start-Triggers {
     )
     Write-Debug "BEGIN: Start-Triggers()"
 
-    [AdfObject[]] $activeTrigger = $adf.Triggers `
-    | Where-Object { $_.Body.properties.runtimeState -eq "Started" } | ToArray
-    Write-Host ("The number of triggers to start: " + $activeTrigger.Count)
+    Write-Host ("TriggerStartMethod = $($adf.PublishOptions.TriggerStartMethod)")
 
-    #Start active triggers - after cleanup efforts
-    $activeTrigger | ForEach-Object { 
-        Write-Host "- Enabling trigger: $($_.Name)"
-        [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$($_.Name)")
-        $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
-        if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
-            Write-host "- Excluded trigger: $($_.Name)" 
-        } else {
+    # Determine triggers to be started
+    if ($adf.PublishOptions.TriggerStartMethod -eq 'KeepPreviousState') {
+        $activeTriggers = $adf.ActiveTriggers | ToArray
+    } else {
+        $activeTriggers = $adf.Triggers `
+        | Where-Object { $_.Body.properties.runtimeState -eq "Started" } | ToArray
+    }
+
+    [System.Collections.ArrayList] $toBeStarted = @{}
+    if ($null -ne $activeTriggers -and $activeTriggers.Count -gt 0)
+    {
+        $activeTriggers | ForEach-Object { 
+            $isStart = $true
+            $triggerName = $_.Name
+            [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$triggerName")
+            # Check whether a trigger is excluded
+            $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
+            if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
+                Write-Host "- Excluded trigger: $triggerName" 
+                $isStart = $false
+            } 
+            # Check whether a trigger has been deleted
+            if ($isStart -and $adf.IsObjectDeleted("trigger.$triggerName")) {
+                Write-Host "- Deleted trigger: $triggerName" 
+                $isStart = $false
+            }
+            # Check whether a trigger has not been stopped    #-and $adf.PublishOptions.TriggerStartMethod -eq 'BasedOnSourceCode' `
+            if ($isStart -and $adf.PublishOptions.TriggerStopMethod  -eq 'DeployableOnly' `
+                         -and $adf.IsTriggerDisabled("$triggerName") -eq $false) {
+                Write-Host "- Trigger already started: $triggerName" 
+                $isStart = $false
+            }
+            if ($isStart) {
+                $toBeStarted.Add($triggerName) | Out-Null
+            }
+        }
+    }
+
+    Write-Host ("The number of triggers to start: " + $toBeStarted.Count)
+
+    # Start triggers
+    if ($toBeStarted.Count -gt 0)
+    {
+        Write-Host "Starting triggers:"
+        $toBeStarted | ForEach-Object { 
             Start-Trigger `
             -ResourceGroupName $adf.ResourceGroupName `
             -DataFactoryName $adf.Name `
-            -Name $_.Name `
+            -Name $_ `
             | Out-Null
         }
+        Write-Host "Complete starting triggers."
     }
 
     Write-Debug "END: Start-Triggers()"

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Stop-Triggers.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Stop-Triggers.ps1
@@ -10,30 +10,61 @@ function Stop-Triggers {
     if ($null -ne $triggersADF) 
     {
         # Goal: Stop all active triggers (<>Stopped) present in ADF service
-        $triggersToStop = $triggersADF | Where-Object { $_.RuntimeState -ne "Stopped" } | ToArray
+        $activeTriggers = $triggersADF | Where-Object { $_.RuntimeState -ne "Stopped" } | ToArray
+        $adf.activeTriggers = $activeTriggers       # Remember to use after the deployment when TriggerStartMethod = 'KeepPreviousState'
         $allAdfTriggersArray = $triggersADF | ToArray
-        Write-Host ("The number of triggers to stop: " + $triggersToStop.Count + " (out of $($allAdfTriggersArray.Count))")
+        Write-Host ("The number of active triggers: " + $activeTriggers.Count + " (out of $($allAdfTriggersArray.Count))")
+        Write-Host ("TriggerStopMethod = $($adf.PublishOptions.TriggerStopMethod)")
 
-        #Stop all triggers
-        if ($null -ne $triggersToStop -and $triggersToStop.Count -gt 0)
+        # Determine triggers to be stopped
+        [System.Collections.ArrayList] $toBeStopped = @{}
+        if ($null -ne $activeTriggers -and $activeTriggers.Count -gt 0)
         {
-            Write-Host "Stopping deployed triggers:"
-            $triggersToStop | ForEach-Object { 
-                [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$($_.Name)")
-                $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
-                if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
-                    Write-host "- Excluded trigger: $($_.Name)" 
-                } else {
-                    Stop-Trigger `
-                    -ResourceGroupName $adf.ResourceGroupName `
-                    -DataFactoryName $adf.Name `
-                    -Name $_.Name `
-                    | Out-Null
+            $activeTriggers | ForEach-Object { 
+                $deploy = $true
+                $triggerName = $_.Name
+                [AdfObjectName] $oname = [AdfObjectName]::new("trigger.$triggerName")
+                # Check whether a trigger is not for deployment
+                if ($adf.PublishOptions.TriggerStopMethod -eq 'DeployableOnly') {
+                    $sourceObject = Get-AdfObjectByName -adf $adf -name $triggerName -type 'Trigger'
+                    if ($null -eq $sourceObject -or $sourceObject.ToBeDeployed -eq $false) {
+                        Write-Host "- Ignored trigger: $triggerName"
+                        $deploy = $false
+                    }
+                }
+                # Check whether a trigger is excluded
+                if ($deploy) {
+                    $IsMatchExcluded = $oname.IsNameExcluded($adf.PublishOptions)
+                    if ($IsMatchExcluded -and $adf.PublishOptions.DoNotStopStartExcludedTriggers) {
+                        Write-Host "- Excluded trigger: $triggerName"
+                        $deploy = $false
+                    } 
+                }
+                if ($deploy) {
+                    $toBeStopped.Add($triggerName) | Out-Null
                 }
             }
-            Write-Host "Complete stopping deployed triggers"
         }
+        Write-Host ("The number of triggers to stop: " + $toBeStopped.Count)
 
+        # Stop triggers
+        if ($toBeStopped.Count -gt 0)
+        {
+            Write-Host "Stopping deployed triggers:"
+            $toBeStopped | ForEach-Object { 
+                Stop-Trigger `
+                -ResourceGroupName $adf.ResourceGroupName `
+                -DataFactoryName $adf.Name `
+                -Name $_ `
+                | Out-Null
+            }
+            Write-Host "Complete stopping deployed triggers."
+        }
+        $adf.DisabledTriggerNames = $toBeStopped
+    }
+    else 
+    {
+        Write-Host ("No remote triggers found.")
     }
 
     Write-Debug "END: Stop-Triggers()"

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Test-LinkedServiceConnection.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Test-LinkedServiceConnection.ps1
@@ -2,7 +2,11 @@
 # https://datathirst.net/blog/2018/9/23/adfv2-testing-linked-services
 
 
-function Get-Bearer([string]$TenantID, [string]$ClientID, [string]$ClientSecret)
+function Get-Bearer(
+  [string] $TenantID, 
+  [string] $ClientID, 
+  [string] $ClientSecret
+)
 {
   $TokenEndpoint = {https://login.windows.net/{0}/oauth2/token} -f $TenantID 
   $ARMResource = "https://management.core.windows.net/";
@@ -14,7 +18,7 @@ function Get-Bearer([string]$TenantID, [string]$ClientID, [string]$ClientSecret)
           'client_secret' = $ClientSecret
   }
 
-  $params = @{
+  $request = @{
       ContentType = 'application/x-www-form-urlencoded'
       Headers = @{'accept'='application/json'}
       Body = $Body
@@ -22,48 +26,138 @@ function Get-Bearer([string]$TenantID, [string]$ClientID, [string]$ClientSecret)
       URI = $TokenEndpoint
   }
 
-  $token = Invoke-RestMethod @params
+  $token = Invoke-RestMethod @request
 
   return "Bearer " + ($token.access_token).ToString()
 }
 
 
-function Get-LinkedServiceBody([string]$LinkedServiceName, [string]$DataFactoryName, [string]$ResourceGroupName, [string]$BearerToken)
+function Get-LinkedServiceBody(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $BearerToken, 
+  [string] $SubscriptionID
+)
 {
+  Write-Debug "BEGIN: Get-LinkedServiceBody()"
   $ADFEndpoint = "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/linkedservices/$($LinkedServiceName)?api-version=2018-06-01"
 
-  $params = @{
+  $request = @{
       ContentType = 'application/json'
       Headers = @{'accept'='application/json';'Authorization'=$BearerToken}
       Method = 'GET'
       URI = $ADFEndpoint
   }
 
-  $a = Invoke-RestMethod @params
+  $a = Invoke-RestMethod @request
+  Write-Debug "END: Get-LinkedServiceBody()"
+  return ConvertTo-Json -InputObject @{"linkedService" = $a} -Depth 50
+}
+
+function Get-LinkedServiceBodyAzRestMethod(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $SubscriptionID,
+  $Params
+)
+{
+  Write-Debug "BEGIN: Get-LinkedServiceBodyAzRestMethod()"
+
+  $ADFEndpoint = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/linkedservices/$($LinkedServiceName)?api-version=2018-06-01"
+
+  $request = @{
+      Path = $ADFEndpoint
+      Method = 'GET'
+  }
+
+  $a = Invoke-AzRestMethod @request
+  $a = ($a.Content | ConvertFrom-Json)
+  #Write-Debug (ConvertTo-Json -InputObject @{"linkedService" = $a} -Depth 50)
+  Write-Debug "END: Get-LinkedServiceBodyAzRestMethod()"
   return ConvertTo-Json -InputObject @{"linkedService" = $a} -Depth 50
 }
 
 
-function Test-LinkedServiceConnection([string]$LinkedServiceName, [string]$DataFactoryName, [string]$ResourceGroupName, [string]$BearerToken)
+function Test-LinkedServiceConnection(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $BearerToken, 
+  [string] $SubscriptionID,
+  $Params
+)
 {
+  Write-Debug "BEGIN: Test-LinkedServiceConnection()"
 
-  $body = Get-LinkedServiceBody -LinkedServiceName $LinkedServiceName -DataFactoryName $DataFactoryName -ResourceGroupName $ResourceGroupName -BearerToken $bearerToken
+  $body = Get-LinkedServiceBody -LinkedServiceName $LinkedServiceName -DataFactoryName $DataFactoryName -ResourceGroupName $ResourceGroupName -BearerToken $bearerToken -SubscriptionID $SubscriptionID
 
   $AzureEndpoint = "https://management.azure.com/subscriptions/$SubscriptionID/resourcegroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/testConnectivity?api-version=2018-06-01"
 
-  $params = @{
+  if ($Params) {
+    Write-Verbose "Found input parameters for this Linked Service, adding to the API request..."
+    $j = ConvertFrom-Json $body 
+    $j.linkedService.properties.parameters = $Params
+    $body = ConvertTo-Json -InputObject $j -Depth 50
+  }
+
+  Write-Verbose '============== Linked Service to being connection tested ============='
+  Write-Verbose $body
+  Write-Verbose '======================================================================'
+  
+  $request = @{
       ContentType = 'application/json'
       Headers = @{'accept'='application/json';'Authorization'=$BearerToken}
       Body = $Body
-      Method = 'Post'
+      Method = 'POST'
       Uri = $AzureEndpoint
   }
 
   try {
-    $response = Invoke-RestMethod @params
+    $response = Invoke-RestMethod @request
   }
   catch {
     Write-Error -Exception $_.Exception
   }
+  Write-Debug "END: Test-LinkedServiceConnection()"
   return $response
+}
+
+function Test-LinkedServiceConnectionAzRestMethod(
+  [string] $LinkedServiceName, 
+  [string] $DataFactoryName, 
+  [string] $ResourceGroupName, 
+  [string] $SubscriptionID,
+  $Params
+)
+{
+  Write-Debug "BEGIN: Test-LinkedServiceConnectionAzRestMethod()"
+
+  $body = Get-LinkedServiceBodyAzRestMethod -LinkedServiceName $LinkedServiceName -DataFactoryName $DataFactoryName -ResourceGroupName $ResourceGroupName -SubscriptionID $SubscriptionID
+
+  $AzureEndpoint = "/subscriptions/$SubscriptionID/resourcegroups/$ResourceGroupName/providers/Microsoft.DataFactory/factories/$DataFactoryName/testConnectivity?api-version=2018-06-01"
+
+  if ($Params) {
+    Write-Verbose "Found input parameters for this Linked Service, adding to the API request..."
+    $j = ConvertFrom-Json $body 
+    $j.linkedService.properties.parameters = $Params
+    $body = ConvertTo-Json -InputObject $j -Depth 50
+  }
+
+  $request = @{
+      Path = $AzureEndpoint
+      Payload = $Body
+      Method = 'POST'
+  }
+
+  try {
+    $response = Invoke-AzRestMethod @request
+  }
+  catch {
+    # Note: Invoke-AzRestMethod fails when payload indicates failure and error will be printed. Not fully feature parity with LinkedServiceConnection
+    Write-Error -Exception $_.Exception
+  }
+  Write-Debug "END: Test-LinkedServiceConnectionAzRestMethod()"
+  return ($response.Content | ConvertFrom-Json)
 }

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Update-GlobalParameters.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/private/Update-GlobalParameters.ps1
@@ -27,12 +27,10 @@ param
             }
             $targetAdf.GlobalParameters = $newGlobalParameters
 
-            # Write-Host "--- newGlobalParameters ---"
-            #$newGlobalParameters.Values | Out-Host
-
             if ($newGlobalParameters.Count -gt 0) {
                 Write-Verbose "Updating $($newGlobalParameters.Count) global parameters..."
-                Set-AzDataFactoryV2 -InputObject $targetAdf -Force | Out-Null
+                #Set-AzDataFactoryV2 -InputObject $targetAdf -Force | Out-Null
+                Set-GlobalParam($adf)
                 Write-Host "Update of $($newGlobalParameters.Count) global parameters complete."
             }
         }

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/public/Import-AdfFromFolder.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/public/Import-AdfFromFolder.ps1
@@ -37,7 +37,9 @@ function Import-AdfFromFolder {
 
     if ( !(Test-Path -Path $RootFolder) ) { Write-Error "ADFT0019: Folder '$RootFolder' doesn't exist." }
     
-    $adf.Location = $RootFolder
+    $adf.Location = Resolve-Path $RootFolder
+    $adf.PublishOptions = New-AdfPublishOption
+    Write-Verbose "Resolved RootFolder = $($adf.Location)"
 
     Import-AdfObjects -Adf $adf -All $adf.IntegrationRuntimes -RootFolder $RootFolder -SubFolder "integrationRuntime" | Out-Null
     Write-Host ("IntegrationRuntimes: {0} object(s) loaded." -f $adf.IntegrationRuntimes.Count)

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/public/New-AdfPublishOption.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/public/New-AdfPublishOption.ps1
@@ -45,6 +45,7 @@ function New-AdfPublishOption {
             Write-Error "ADFT0026: File does not exist: $FilterFilePath"
         }
         $FilterText = Get-Content -Path $FilterFilePath -Encoding "UTF8"
+        if ($null -eq $FilterText) { $FilterText = '' }
 
         $FilterArray = $FilterText.Replace(',', "`n").Replace("`r`n", "`n").Split("`n");
 

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2FromJson.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2FromJson.ps1
@@ -168,7 +168,7 @@ function Publish-AdfV2FromJson {
         }
 
         if ($null -eq $targetAdf) {
-            Write-Host "The process is exiting the function. Do fix the issue and run again."
+            Write-Host "ADFT0032: The process is exiting the function. Do fix the issue and run again."
             return 
         }
     }
@@ -304,12 +304,13 @@ function Publish-AdfV2FromJson {
         $adfIns.AllObjects() | ForEach-Object {
             Remove-AdfObjectIfNotInSource -adfSource $adf -adfTargetObj $_ -adfInstance $adfIns
         }
+        Write-Host "Deleted $($adf.DeletedObjectNames.Count) objects from ADF service."
     } else {
         Write-Host "Operation skipped as publish option 'DeleteNotInSource' = false"
     }
 
     Write-Host "===================================================================================";
-    Write-Host "STEP: Starting all triggers..."
+    Write-Host "STEP: Starting triggers..."
     if ($opt.StopStartTriggers -eq $true) {
         Start-Triggers -adf $adf
     } else {

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2UsingArm.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/public/Publish-AdfV2UsingArm.ps1
@@ -124,7 +124,7 @@ function Publish-AdfV2UsingArm {
         }
 
         if ($null -eq $targetAdf) {
-            Write-Host "The process is exiting the function. Do fix the issue and run again."
+            Write-Host "ADFT0032: The process is exiting the function. Do fix the issue and run again."
             return 
         }
     }

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/public/Test-AdfCode.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/public/Test-AdfCode.ps1
@@ -86,8 +86,8 @@ function Test-AdfCode {
         }
     }
 
-    Write-Host "Checking names of datasets, pipelines, dataflows..."
-    $adf.LinkedServices + $adf.DataSets + $adf.Pipelines + $adf.DataFlows | ForEach-Object {
+    Write-Host "Checking names of linkedservices, datasets, dataflows..."
+    $adf.LinkedServices + $adf.DataSets + $adf.DataFlows | ForEach-Object {
         [string] $name = $_.Name
         if ($name.Contains('-')) {
             Write-Warning "Dashes ('-') are not allowed in the names of linked services, data flows, and datasets ($name)."

--- a/testLinkedServiceTask/ps_modules/azure.datafactory.tools/public/Test-AdfLinkedService.ps1
+++ b/testLinkedServiceTask/ps_modules/azure.datafactory.tools/public/Test-AdfLinkedService.ps1
@@ -1,36 +1,89 @@
 function Test-AdfLinkedService {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'AzRestMethod')]
     param (
-        [parameter(Mandatory = $true)] 
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $LinkedServiceName,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $DataFactoryName,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $ResourceGroupName,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'AzRestMethod')]
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $SubscriptionID,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $TenantID,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $ClientID,
-        [parameter(Mandatory = $true)] 
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ClientDetails')]
         [String] $ClientSecret
     )
+    Write-Debug "BEGIN: Test-AdfLinkedService(ParameterSetName = $($PSCmdlet.ParameterSetName))"
 
-    $bearerToken = Get-Bearer -TenantID $TenantID -ClientID $ClientID -ClientSecret $ClientSecret
+    if ($PSCmdlet.ParameterSetName -eq "ClientDetails") {
+        $bearerToken = Get-Bearer -TenantID $TenantID -ClientID $ClientID -ClientSecret $ClientSecret
+    }
+    $defFile = $false
+    if ($LinkedServiceName.EndsWith('.json'))
+    {
+        Write-Host "Definition of Linked Services in json file: $LinkedServiceName"
+        $definitionFile = Get-Content -Path $LinkedServiceName -Encoding utf8 -Raw
+        $j = $definitionFile | ConvertFrom-Json
+        $list = $j.linkedServices
+        Write-Host "Found $($list.Count) name(s) in definition file."
+        $defFile = $true
+    }
+    else {
+        $list = $LinkedServiceName.Split(',')
+        Write-Host "Found $($list.Count) name(s) in comma-separated list."
+    }
 
+    $report = @{}
     $all = 0
     $ok = 0
-    $LinkedServiceName.Split(',') | ForEach-Object { 
+    $list | ForEach-Object { 
         $all += 1
-        $ls = $_
-        Write-Host "Testing ADF Linked Service connection: [$_] ..." 
-        $r = Test-LinkedServiceConnection -LinkedServiceName $ls -DataFactoryName $DataFactoryName -ResourceGroup $ResourceGroupName -BearerToken $bearerToken
+        if ($defFile) { 
+            $ls = $_.name 
+            $params = $_.parameters
+        } 
+        else 
+        { 
+            $ls = $_ 
+            $params = $null
+        }
+        Write-Host "Testing ADF Linked Service connection: [$ls] ..." 
+        if ($PSCmdlet.ParameterSetName -eq "ClientDetails") {
+            $r = Test-LinkedServiceConnection -LinkedServiceName $ls `
+                -DataFactoryName $DataFactoryName `
+                -ResourceGroup $ResourceGroupName `
+                -BearerToken $bearerToken `
+                -SubscriptionID $SubscriptionID `
+                -Params $params
+        } else {
+            $r = Test-LinkedServiceConnectionAzRestMethod -LinkedServiceName $ls `
+                -DataFactoryName $DataFactoryName `
+                -ResourceGroup $ResourceGroupName `
+                -SubscriptionID $SubscriptionID `
+                -Params $params
+        }
+        $id = [String]::Format("{0:000}) {1}", $all, $ls)
         if ($null -ne $r -and $r.succeeded) {
-            Write-Host "[$_] : Connection successful."
+            Write-Host "$all) [$ls] : Connection successful."
+            $report.Add($id, $true)
             $ok += 1
         } else {
-            Write-Host "[$_] : Connection failed."
+            Write-Host "$all) [$ls] : Connection failed."
+            $report.Add($id, $false)
+            Write-Verbose ($r | ConvertTo-Json)
         }
     }
     
@@ -39,5 +92,8 @@ function Test-AdfLinkedService {
     Write-Host "Failed: $($all-$ok)"
     Write-Host "Total : $all"
 
+    Write-Debug "END: Test-AdfLinkedService()"
+    $result = [ordered]@{Passed = $ok; Failed = ($all-$ok); Total = $all; Report = $report}
+    return $result
 }
 

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "DataFactoryTools",
     "name": "Deploy Azure Data Factory (#adftools)",
-    "version": "1.29.0000",
+    "version": "1.30.0000",
     "publisher": "SQLPlayer",
     "description": "Tools for deploying entire ADF code (JSON files) to ADF instance",
     "targets": [


### PR DESCRIPTION
# 17 Jul 2023 - v.1.30  
Update [adftools v.1.6.3](https://github.com/Azure-Player/azure.datafactory.tools/releases/tag/v1.6.3):  
  - Stop and restart only changed triggers  
  - New option to Stop/Start only the triggers that are already Started  
  - Remove pipeline's from check (`Test-AdfCode`) for dashes in name  
  - Test-AdfLinkedService - minor enhancements  
  - Fixed: `RootFolder` must be absolute otherwise temp files cannot be written  
  - Fixed: Catch InvalidOperation exception when reading empty FilterFilePath in New-AdfPublishOption.ps1  
  - Fixed: Purview configuration gets overwritten when deploy Global Parameters using ADF deployment task  
  - Fixed: Incremental Deployment seems to not work when factory folder does not exist  
  - Fixed: The publish cmdlet tries to delete enabled (active) trigger (not in source) when TriggerStartMethod = KeepPreviousState  
  - Fixed: deletion of credential type of objects  
  - Fixed: `Test-AdfCode` for [credential] objects  
